### PR TITLE
Add Vietnamese localization and documentation for Polyglot NVDA add-on

### DIFF
--- a/addon/doc/vi/readme.md
+++ b/addon/doc/vi/readme.md
@@ -1,0 +1,195 @@
+# Polyglot cho NVDA
+
+Polyglot là một add-on toàn cục dành cho NVDA, tập trung vào khả năng dịch thuật đa ngôn ngữ nhanh chóng và linh hoạt. Add-on này có thể dịch văn bản đang được chọn, nội dung trong bộ nhớ tạm, đoạn văn bản được NVDA đọc gần nhất, và cũng có thể chặn nội dung giọng đọc để dịch tự động trực tiếp.
+
+Add-on được xây dựng trên cấu trúc bộ dịch động. Các bộ dịch sẽ tự khai báo khả năng và sơ đồ cấu hình của riêng mình, từ đó giao diện cài đặt sẽ được tạo tự động dựa trên sơ đồ đó khi chạy ứng dụng. Điều này giúp cho phần cốt lõi của plugin luôn gọn nhẹ nhưng lại rất dễ dàng để tích hợp thêm các dịch vụ mới.
+
+## Các tính năng chính
+
+- Dịch văn bản đang chọn, văn bản trong bộ nhớ tạm và câu nói gần nhất của NVDA.
+- Cung cấp một lớp lệnh dịch thuật qua tổ hợp `NVDA+Alt+Z`; nhấn `H` khi đang ở trong lớp lệnh để xem trợ giúp.
+- Hỗ trợ dịch tự động trực tiếp nội dung giọng đọc của NVDA.
+- Tích hợp bộ lọc giọng đọc thông minh giúp loại bỏ các thông tin gây nhiễu không cần dịch như vai trò, trạng thái và định dạng.
+- Lưu bộ nhớ đệm dịch thuật để giảm các yêu cầu trùng lặp.
+- Có thể tự động sao chép kết quả dịch thủ công vào bộ nhớ tạm.
+- Cho phép chuyển đổi bộ dịch và ngôn ngữ ngay trên bàn phím mà không cần rời khỏi cửa sổ đang làm việc.
+- Cung cấp một hộp thoại dịch thuật tương tác chuyên dụng dành cho các văn bản dài hoặc khi cần dịch lặp đi lặp lại.
+
+## Cài đặt
+
+Cách cài đặt được khuyến nghị là thông qua Cửa hàng Add-on của NVDA (NVDA Add-on Store). Bạn cũng có thể cài đặt thủ công bằng cách:
+
+1. Tải xuống gói `.nvda-addon` mới nhất từ [Trang phát hành](https://github.com/cary-rowen/polyglot/releases).
+2. Mở tệp vừa tải xuống.
+3. Xác nhận cài đặt trong NVDA.
+4. Khởi động lại NVDA khi được yêu cầu.
+
+## Khởi động nhanh
+
+1. Mở `Trình đơn NVDA -> Tùy Chọn -> Cấu hình -> Polyglot`.
+2. Chọn một bộ dịch và đảm bảo rằng bộ dịch đó đã được bật.
+3. Cấu hình các thông tin xác thực cần thiết (nếu có) cho bộ dịch đó.
+4. Thiết lập ngôn ngữ nguồn và ngôn ngữ đích.
+5. Tùy chọn bật tính năng tự động sao chép vào bộ nhớ tạm và bộ lọc giọng đọc thông minh.
+6. Nhấn `NVDA+Alt+Z`, sau đó sử dụng một trong các phím thuộc lớp lệnh bên dưới. Nhấn `H` trong lớp lệnh để xem trợ giúp.
+
+## Lớp lệnh
+
+Nhấn `NVDA+Alt+Z` để vào lớp lệnh. Một tiếng bíp ngắn sẽ phát ra để xác nhận lớp lệnh đang hoạt động. Nhấn `H` trong lớp lệnh để xem trợ giúp về lớp lệnh. Hầu hết các lệnh sẽ thực thi một lần rồi thoát khỏi lớp lệnh. Các lệnh chuyển đổi ngôn ngữ và bộ dịch sẽ giữ bạn ở lại trong lớp lệnh để bạn có thể tiếp tục xoay vòng chuyển đổi. Việc chuyển đổi bộ dịch sẽ chỉ xoay vòng qua các bộ dịch đã được bật.
+
+| Phím | Hành động |
+| --- | --- |
+| `T` | Dịch nội dung đang chọn. |
+| `Shift+T` | Dịch nội dung đang chọn theo chiều ngược lại. |
+| `B` | Dịch văn bản trong bộ nhớ tạm. |
+| `Shift+B` | Dịch văn bản trong bộ nhớ tạm theo chiều ngược lại. |
+| `L` | Dịch nội dung văn bản vừa được NVDA đọc gần nhất. |
+| `Shift+L` | Dịch nội dung văn bản vừa được NVDA đọc gần nhất theo chiều ngược lại. |
+| `S` | Ngôn ngữ nguồn tiếp theo. |
+| `Shift+S` | Ngôn ngữ nguồn trước đó. |
+| `G` | Ngôn ngữ đích tiếp theo. |
+| `Shift+G` | Ngôn ngữ đích trước đó. |
+| `E` | Bộ dịch đã bật tiếp theo. |
+| `Shift+E` | Bộ dịch đã bật trước đó. |
+| `W` | Hoán đổi ngôn ngữ nguồn và ngôn ngữ đích. |
+| `A` | Đọc bộ dịch và cặp ngôn ngữ hiện tại. |
+| `C` | Sao chép kết quả dịch gần nhất. |
+| `V` | Bật/tắt dịch tự động. |
+| `I` | Mở hộp thoại dịch thuật tương tác. |
+| `O` | Mở cài đặt Polyglot. |
+| `X` | Xóa bộ nhớ đệm dịch thuật. |
+| `H` | Hiển thị trợ giúp về lớp lệnh. |
+
+## Hộp thoại dịch thuật tương tác
+
+Hộp thoại tương tác được thiết kế dành cho các văn bản dài và công việc dịch thuật cần chỉnh sửa nhiều lần.
+
+- Mở hộp thoại từ lớp lệnh bằng phím `I`.
+- Chọn bộ dịch đã bật, ngôn ngữ nguồn và ngôn ngữ đích ngay trong hộp thoại mà không cần thoát ra ngoài.
+- Các bộ dịch bị tắt vẫn có thể cấu hình được trong phần cài đặt chung, nhưng sẽ không hiển thị trong hộp thoại này.
+- Đối với các bộ dịch dạng mô hình ngôn ngữ lớn (LLM), bạn có thể điều chỉnh mô hình và mẫu lời nhắc trực tiếp ngay trong hộp thoại.
+- Nhấn `Ctrl+Enter` tại ô văn bản nguồn để thực hiện dịch.
+- Sao chép kết quả hoặc xóa trống cả hai ô mà không cần phải mở lại cửa sổ.
+
+## Hướng dẫn cài đặt
+
+### Cài đặt chung
+
+- `Sao chép kết quả dịch thủ công vào bộ nhớ tạm`: Tự động sao chép kết quả dịch thủ công sau khi yêu cầu dịch thành công.
+- `Bật bộ lọc giọng đọc thông minh`: Khi dịch nội dung nói của NVDA, bộ lọc sẽ bỏ qua các lời thoại không phải nội dung chính như vai trò, trạng thái, vị trí và chi tiết định dạng nếu có thể.
+- `Xóa bộ nhớ đệm`: Xóa bộ nhớ đệm dịch thuật đã lưu và hiển thị số lượng mục hiện tại ngay trên nhãn của nút bấm.
+
+### Cài đặt dùng chung cho các bộ dịch
+
+Hầu hết các bộ dịch đều kế thừa một tập hợp các cài đặt chung:
+
+- `Bật bộ dịch này`: Kiểm soát việc bộ dịch này có sẵn sàng cho các yêu cầu dịch, chuyển đổi bộ dịch trong lớp lệnh và hiển thị trong hộp thoại tương tác hay không. Các bộ dịch bị tắt vẫn sẽ hiển thị và có thể cấu hình được trong phần cài đặt.
+- `Ngôn ngữ nguồn` và `Ngôn ngữ đích`
+- `Chế độ Proxy`: Sử dụng cài đặt proxy của hệ thống hoặc tắt tính năng sử dụng proxy.
+- `Thời gian chờ yêu cầu`
+
+Nếu bộ dịch có hỗ trợ báo cáo ngôn ngữ nguồn phát hiện được, Polyglot cũng sẽ cung cấp thêm:
+
+- `Tự động hoán đổi nếu nguồn phát hiện trùng với đích`: Rất hữu ích khi ngôn ngữ nguồn được đặt là tự động phát hiện.
+- `Ngôn ngữ hoán đổi sang`: Ngôn ngữ đích thay thế được sử dụng trong quá trình tự động hoán đổi.
+
+### Hành vi dịch tự động
+
+- Tính năng dịch tự động sẽ tác động lên nội dung nói của NVDA được thu thập từ quy trình xử lý giọng đọc.
+- Add-on sẽ tự động chặn các thông báo giọng đọc của chính nó để tránh rơi vào vòng lặp dịch thuật vô hạn.
+- Nếu tính năng dịch tự động bị lỗi 3 lần liên tiếp, nó sẽ tự động tắt.
+- Bộ lọc giọng đọc thông minh chủ yếu ảnh hưởng đến việc dịch nội dung giọng đọc phát ra, không ảnh hưởng đến việc dịch văn bản thủ công tiêu chuẩn.
+
+### Các tùy chọn dành riêng cho LLM và Polyglot
+
+Một số bộ dịch sẽ hiển thị thêm các trình điều khiển bổ sung:
+
+- `Ollama 1` và `Ollama 2` cung cấp hai cấu hình lưu trữ riêng biệt cho các thiết lập Ollama cục bộ hoặc từ xa khác nhau.
+- `OpenRouter` hiển thị các trường API URL, khóa API, mô hình đặt trước, tên mô hình tùy chỉnh, mẫu lời nhắc và các lời nhắc tùy chỉnh.
+- Các bộ dịch `Ollama` hiển thị API URL, tên mô hình, khóa API tùy chọn, mẫu lời nhắc và các lời nhắc tùy chỉnh.
+- `Google Translate (Polyglot)` hiển thị một trường API URL endpoint và trường khóa API có thể cấu hình.
+- `Google Translate (key-free)` cung cấp một nút công tắc bật/tắt máy chủ dự phòng tùy chọn.
+
+## Dịch ngoại tuyến bằng Chrome AI
+
+Polyglot có thể sử dụng API dịch thuật tích hợp sẵn của Chrome để dịch ngoại tuyến. Quá trình dịch thuật được xử lý bởi một tiến trình Chrome cục bộ lập riêng biệt, vì vậy văn bản sẽ không bị gửi đến bất kỳ dịch vụ dịch thuật bên thứ ba nào.
+
+### Yêu cầu hệ thống
+
+- Máy tính phải được cài đặt Google Chrome.
+- Khuyến nghị sử dụng Chrome phiên bản 138 trở lên.
+- Lần đầu tiên sử dụng một chiều ngôn ngữ nào đó, mô hình dịch thuật cục bộ cần phải được chuẩn bị trước. Polyglot có thể tải xuống mô hình này thông qua trình quản lý mô hình của nó, hoặc bạn có thể để Chrome tự tải xuống.
+
+### Cách sử dụng
+
+Chọn `Chrome AI (Offline)` trong phần cài đặt Polyglot, sau đó chọn ngôn ngữ nguồn và ngôn ngữ đích. Chrome AI yêu cầu phải có ngôn ngữ nguồn rõ ràng; tùy chọn `Tự động phát hiện` không khả dụng cho bộ dịch này, nhờ đó Polyglot có thể kiểm tra mô hình cần thiết trước khi khởi chạy Chrome.
+
+Trong lần đầu sử dụng, nếu mô hình cần thiết chưa được cài đặt, Polyglot sẽ hỏi bạn muốn tiếp tục như thế nào. Chọn Có để tải xuống và cài đặt mô hình bằng trình quản lý mô hình của Polyglot; hãy dùng cách này nếu dịch vụ tải mô hình của Chrome quá chậm, bị chặn hoặc không ổn định trên mạng của bạn. Chọn Không để Chrome tự tải xuống mô hình. Chọn Hủy bỏ để hủy lượt dịch hiện tại. Sau khi mô hình đã sẵn sàng, quá trình dịch sẽ tự động tiếp tục.
+
+### Mạng và Mô hình
+
+Quá trình dịch thuật diễn ra hoàn toàn cục bộ. Các mô hình có thể được cài đặt bởi trình quản lý mô hình của Polyglot hoặc được tải xuống bởi Chrome. Nếu dịch vụ tải mô hình của Chrome quá chậm hoặc không khả dụng trên mạng của bạn, hãy chọn Có khi có hộp thoại nhắc, hoặc mở Trình quản lý mô hình ChromeAI Polyglot từ menu Công cụ (Tools) của NVDA để cài đặt hoặc gỡ bỏ các mô hình ngoại tuyến trước.
+
+### Quyền riêng tư và Dữ liệu
+
+Polyglot sử dụng một thư mục dữ liệu Chrome tách biệt dành cho Chrome AI, vì vậy nó không ảnh hưởng đến hồ sơ (profile) Chrome thông thường của bạn. Các mô hình, dữ liệu bộ nhớ đệm và dữ liệu thực thi được lưu giữ để tránh việc phải tải xuống lại nhiều lần.
+
+Đường dẫn mặc định là:
+
+```text
+%LOCALAPPDATA%\Polyglot\ChromeAI
+```
+
+Nếu biến môi trường `LOCALAPPDATA` không khả dụng, Polyglot sẽ dùng thư mục tạm thời `polyglot_chrome_ai` nằm dưới thư mục cấu hình của NVDA.
+
+Khi NVDA thoát, Polyglot sẽ đóng tiến trình Chrome mà nó đã khởi chạy.
+
+### Hạn chế
+
+- Các ngôn ngữ và cặp ngôn ngữ được hỗ trợ sẽ do API dịch thuật của Chrome quyết định.
+- Chrome AI yêu cầu phải có ngôn ngữ nguồn rõ ràng; không hỗ trợ tính năng `Tự động phát hiện`.
+- Lần đầu sử dụng yêu cầu mô hình phải được chuẩn bị sẵn; việc tải xuống mô hình có thể bị ảnh hưởng bởi điều kiện mạng.
+- Nếu API dịch thuật không khả dụng, hãy cập nhật Chrome hoặc đảm bảo rằng tính năng liên quan của Chrome đã được bật.
+
+## Tổng quan về các bộ dịch
+
+Kho lưu trữ hiện tại bao gồm các bộ dịch sau:
+
+| Bộ dịch | Thông tin xác thực | Ghi chú |
+| --- | --- | --- |
+| `Baidu Translate` | Baidu app ID và secret | Tích hợp API chuẩn của nhà cung cấp. |
+| `Caiyun` | Caiyun token | Tích hợp API chuẩn của nhà cung cấp. |
+| `Chrome AI (Offline)` | Không có | Sử dụng API dịch thuật tích hợp sẵn của Chrome với các mô hình cục bộ; yêu cầu chọn rõ ràng ngôn ngữ nguồn. |
+| `DeepL` | DeepL API key | Tích hợp API chuẩn của nhà cung cấp. |
+| `Google Translate (key-free)` | Không có | Hỗ trợ nút bật/tắt chuyển đổi sang máy chủ dự phòng tùy chọn. |
+| `Google Translate (Polyglot)` | Khóa API và endpoint có thể cấu hình | Đi kèm với các giá trị endpoint mặc định trong mã nguồn; tính khả dụng tùy thuộc vào trạng thái dịch vụ. |
+| `Lingva Translate` | Không có | Endpoint công cộng của Lingva, không có báo cáo phát hiện ngôn ngữ trong phản hồi. |
+| `Microsoft Translator (key-free)` | Không có | Tự động lấy mã token tạm thời. |
+| `Niutrans` | Niutrans API key | Tích hợp API chuẩn của nhà cung cấp. |
+| `Ollama 1` | Ollama URL, tên mô hình, khóa tùy chọn | Cấu hình hồ sơ Ollama đã lưu thứ nhất. |
+| `Ollama 2` | Ollama URL, tên mô hình, khóa tùy chọn | Cấu hình hồ sơ Ollama đã lưu thứ hai. |
+| `OpenRouter` | OpenRouter API key | Hỗ trợ các mô hình đặt trước và mẫu lời nhắc có thể chỉnh sửa. |
+| `Tencent Translate` | Tencent secret ID và secret key | Tích hợp API chuẩn của nhà cung cấp. |
+| `Tencent Translate (Polyglot)` | Tên người dùng và mật khẩu NVDACN | Tuyến đường Tencent được hỗ trợ bởi Polyglot. |
+| `VIVO Translate` | Tên người dùng và mật khẩu NVDACN | Tập hợp ngôn ngữ hạn chế, không có tính năng tự động phát hiện ngôn ngữ nguồn. |
+| `Volcengine (Polyglot)` | Tên người dùng và mật khẩu NVDACN | Tuyến đường Volcengine được hỗ trợ bởi Polyglot. |
+| `Yandex Translate` | Không có | Endpoint dạng công cộng, không có báo cáo ngôn ngữ phát hiện được. |
+
+## Đóng góp phát triển
+
+Mọi đóng góp luôn được chào đón từ mã nguồn, tài liệu, bản dịch ngôn ngữ, kiểm thử cho đến tích hợp các bộ dịch mới.
+
+- Báo cáo lỗi: [GitHub Issues](https://github.com/cary-rowen/polyglot/issues)
+- Các bản phát hành: [GitHub Releases](https://github.com/cary-rowen/polyglot/releases)
+
+Khi thêm một bộ dịch mới:
+
+1. Tạo một module tại thư mục `addon/globalPlugins/polyglot/services/engines/`.
+2. Triển khai lớp `TranslationEngine` hoặc đối với các bộ dịch HTTP, mở rộng từ lớp `BaseHttpEngine`.
+3. Trả về một đặc tả cấu hình (config spec) từ hàm `getConfigSpec()` nếu bộ dịch đó cần các cài đặt.
+4. Sử dụng các loại trình điều khiển được hỗ trợ từ `views/factory.py`: `choice`, `text`, `password`, `checkbox`, và `spinctrl`.
+5. Xác minh bộ dịch hiển thị chính xác trong bảng cài đặt động, và khi được bật, kiểm tra hoạt động chuyển đổi trong lớp lệnh cũng như trong hộp thoại tương tác.
+
+## Giấy phép
+
+Dự án này được cấp phép theo Giấy phép Công cộng Toàn quyền GNU phiên bản 2 (GPL v2). Xem chi tiết tại [COPYING.txt](COPYING.txt).

--- a/addon/locale/vi/LC_MESSAGES/nvda.po
+++ b/addon/locale/vi/LC_MESSAGES/nvda.po
@@ -1,0 +1,1950 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the polyglot package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: polyglot 0.9.1\n"
+"Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
+"POT-Creation-Date: 2026-06-09 09:33+0800\n"
+"PO-Revision-Date: 2026-06-12 09:48+0700\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
+
+#. Add-on summary/title, usually the user visible name of the add-on
+#. Translators: Summary/title for this add-on
+#. to be shown on installation and add-on information found in add-on store
+#: addon\globalPlugins\polyglot\__init__.py:75
+#: addon\globalPlugins\polyglot\views\settings.py:21 buildVars.py:23
+msgid "Polyglot"
+msgstr "Polyglot"
+
+#: addon\globalPlugins\polyglot\__init__.py:135
+msgid "Enter the translation command layer; press H for command layer help"
+msgstr "Vào lớp lệnh dịch thuật; nhấn H để xem trợ giúp về lớp lệnh"
+
+#: addon\globalPlugins\polyglot\__init__.py:150
+msgid "Nothing selected"
+msgstr "Chưa chọn nội dung nào"
+
+#: addon\globalPlugins\polyglot\__init__.py:155
+msgid "Cannot get selected text from the current object"
+msgstr "Không thể lấy văn bản được chọn từ đối tượng hiện tại"
+
+#: addon\globalPlugins\polyglot\__init__.py:181
+msgid "Next source language"
+msgstr "Ngôn ngữ nguồn tiếp theo"
+
+#: addon\globalPlugins\polyglot\__init__.py:187
+msgid "Previous source language"
+msgstr "Ngôn ngữ nguồn trước đó"
+
+#: addon\globalPlugins\polyglot\__init__.py:193
+msgid "Next target language"
+msgstr "Ngôn ngữ đích tiếp theo"
+
+#: addon\globalPlugins\polyglot\__init__.py:199
+msgid "Previous target language"
+msgstr "Ngôn ngữ đích trước đó"
+
+#: addon\globalPlugins\polyglot\__init__.py:211
+msgid "Next translation engine"
+msgstr "Bộ dịch tiếp theo"
+
+#: addon\globalPlugins\polyglot\__init__.py:217
+msgid "Previous translation engine"
+msgstr "Bộ dịch trước đó"
+
+#: addon\globalPlugins\polyglot\__init__.py:223
+msgid "Swap source and target languages"
+msgstr "Hoán đổi ngôn ngữ nguồn và đích"
+
+#: addon\globalPlugins\polyglot\__init__.py:232
+msgid "Announce current engine and languages"
+msgstr "Đọc bộ dịch và ngôn ngữ hiện tại"
+
+#: addon\globalPlugins\polyglot\__init__.py:239
+msgid "Copy last translation to clipboard"
+msgstr "Sao chép kết quả dịch gần nhất vào bộ nhớ tạm"
+
+#: addon\globalPlugins\polyglot\__init__.py:245
+msgid "No translation result to copy"
+msgstr "Không có kết quả dịch nào để sao chép"
+
+#: addon\globalPlugins\polyglot\__init__.py:247
+msgid "Open interactive translation dialog"
+msgstr "Mở hộp thoại dịch thuật tương tác"
+
+#: addon\globalPlugins\polyglot\__init__.py:260
+msgid "Open settings"
+msgstr "Mở cài đặt"
+
+#: addon\globalPlugins\polyglot\__init__.py:268
+msgid "Toggle auto-translation"
+msgstr "Bật/tắt dịch tự động"
+
+#: addon\globalPlugins\polyglot\__init__.py:271
+msgid "Auto-translation enabled"
+msgstr "Đã bật dịch tự động"
+
+#: addon\globalPlugins\polyglot\__init__.py:271
+msgid "Auto-translation disabled"
+msgstr "Đã tắt dịch tự động"
+
+#: addon\globalPlugins\polyglot\__init__.py:273
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:212
+msgid "Clear cache"
+msgstr "Xóa bộ nhớ đệm"
+
+#: addon\globalPlugins\polyglot\__init__.py:276
+msgid "Cache cleared"
+msgstr "Đã xóa bộ nhớ đệm"
+
+#: addon\globalPlugins\polyglot\__init__.py:278
+msgid "Translate selection"
+msgstr "Dịch nội dung đang chọn"
+
+#: addon\globalPlugins\polyglot\__init__.py:283
+msgid "Translate selection (reversed direction)"
+msgstr "Dịch nội dung đang chọn (theo chiều ngược lại)"
+
+#: addon\globalPlugins\polyglot\__init__.py:288
+msgid "Translate clipboard"
+msgstr "Dịch nội dung trong bộ nhớ tạm"
+
+#: addon\globalPlugins\polyglot\__init__.py:291
+#: addon\globalPlugins\polyglot\__init__.py:298
+msgid "Clipboard is empty"
+msgstr "Bộ nhớ tạm đang trống"
+
+#: addon\globalPlugins\polyglot\__init__.py:295
+msgid "Translate clipboard (reversed direction)"
+msgstr "Dịch nội dung trong bộ nhớ tạm (theo chiều ngược lại)"
+
+#: addon\globalPlugins\polyglot\__init__.py:302
+msgid "Translate last spoken text"
+msgstr "Dịch nội dung vừa được đọc gần nhất"
+
+#: addon\globalPlugins\polyglot\__init__.py:305
+#: addon\globalPlugins\polyglot\__init__.py:312
+msgid "No last spoken text"
+msgstr "Không có nội dung được đọc gần nhất"
+
+#: addon\globalPlugins\polyglot\__init__.py:309
+msgid "Translate last spoken text (reversed direction)"
+msgstr "Dịch nội dung vừa được đọc gần nhất (theo chiều ngược lại)"
+
+#: addon\globalPlugins\polyglot\__init__.py:316
+msgid "Show command layer help"
+msgstr "Hiển thị trợ giúp về lớp lệnh"
+
+#: addon\globalPlugins\polyglot\__init__.py:320
+msgid "Polyglot Help"
+msgstr "Trợ giúp Polyglot"
+
+#: addon\globalPlugins\polyglot\__init__.py:329
+msgid "Translation Actions"
+msgstr "Hành động dịch"
+
+#: addon\globalPlugins\polyglot\__init__.py:340
+msgid "Configuration & Switching"
+msgstr "Cấu hình & Chuyển đổi"
+
+#: addon\globalPlugins\polyglot\__init__.py:353
+msgid "Tools & System"
+msgstr "Công cụ & Hệ thống"
+
+#: addon\globalPlugins\polyglot\__init__.py:375
+msgid "Key"
+msgstr "Khóa"
+
+#: addon\globalPlugins\polyglot\__init__.py:375
+msgid "Action"
+msgstr "Hành động"
+
+#: addon\globalPlugins\polyglot\app\manager.py:63
+#: addon\globalPlugins\polyglot\app\manager.py:103
+msgid "Invalid engine configuration."
+msgstr "Cấu hình bộ dịch không hợp lệ."
+
+#: addon\globalPlugins\polyglot\app\manager.py:72
+msgid "Swap failed: 'Auto-detect' cannot be the target language."
+msgstr ""
+"Hoán đổi thất bại: Không thể chọn 'Tự động phát hiện' làm ngôn ngữ đích."
+
+#. Translators: A message indicating that the source and target languages have been swapped. {source} is the new source language, {target} is the new target language.
+#: addon\globalPlugins\polyglot\app\manager.py:79
+#, python-brace-format
+msgid "Languages swapped: from {source} to {target}"
+msgstr "Đã hoán đổi ngôn ngữ: từ {source} sang {target}"
+
+#: addon\globalPlugins\polyglot\app\manager.py:123
+msgid "No languages available for cycling."
+msgstr "Không có ngôn ngữ nào khả dụng để xoay vòng chuyển đổi."
+
+#: addon\globalPlugins\polyglot\app\manager.py:148
+msgid "No translation engines available."
+msgstr "Không có bộ dịch nào khả dụng."
+
+#: addon\globalPlugins\polyglot\app\manager.py:153
+#: addon\globalPlugins\polyglot\app\manager.py:277
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:44
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:237
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:271
+msgid "No enabled translation engines available."
+msgstr "Không có bộ dịch khả dụng nào được bật."
+
+#. Translators: Announcement of the current translation engine and languages. {engine} is the engine name, {source} is the source language, {target} is the target language.
+#: addon\globalPlugins\polyglot\app\manager.py:171
+#, python-brace-format
+msgid "{engine}, from {source} to {target}"
+msgstr "{engine}, từ {source} sang {target}"
+
+#: addon\globalPlugins\polyglot\app\manager.py:180
+msgid "Languages not configured or current engine is invalid"
+msgstr "Ngôn ngữ chưa được cấu hình hoặc bộ dịch hiện tại không hợp lệ"
+
+#: addon\globalPlugins\polyglot\app\manager.py:225
+msgid "Languages not configured, cannot reverse."
+msgstr "Ngôn ngữ chưa được cấu hình, không thể đảo chiều dịch."
+
+#: addon\globalPlugins\polyglot\app\manager.py:231
+msgid "Reverse failed: 'Auto-detect' cannot be the target language."
+msgstr ""
+"Đảo chiều thất bại: Không thể chọn 'Tự động phát hiện' làm ngôn ngữ đích."
+
+#: addon\globalPlugins\polyglot\app\manager.py:234
+msgid "Current translation engine is invalid."
+msgstr "Bộ dịch hiện tại không hợp lệ."
+
+#: addon\globalPlugins\polyglot\app\manager.py:249
+msgid "Nothing to translate"
+msgstr "Không có gì để dịch"
+
+#: addon\globalPlugins\polyglot\app\manager.py:263
+#, python-brace-format
+msgid "Error: Selected engine '{engine}' is unavailable or not configured."
+msgstr ""
+"Lỗi: Bộ dịch được chọn '{engine}' không khả dụng hoặc chưa được cấu hình."
+
+#. Translators: Error message when the selected translation engine is not configured properly. {engine} is the internal ID of the engine.
+#: addon\globalPlugins\polyglot\app\manager.py:307
+#, python-brace-format
+msgid "Error: Engine '{engine}' is not configured."
+msgstr "Lỗi: Bộ dịch '{engine}' chưa được cấu hình."
+
+#: addon\globalPlugins\polyglot\app\manager.py:371
+msgid "Translation failed: "
+msgstr "Dịch thất bại: "
+
+#: addon\globalPlugins\polyglot\app\manager.py:375
+msgid "An unknown error occurred"
+msgstr "Đã xảy ra lỗi không xác định"
+
+#: addon\globalPlugins\polyglot\app\manager.py:389
+msgid "Auto-translation disabled due to repeated failures."
+msgstr "Đã tắt dịch tự động do gặp lỗi liên tiếp nhiều lần."
+
+#: addon\globalPlugins\polyglot\common\cues.py:171
+#, python-format
+msgid "%d percent"
+msgstr "%d phần trăm"
+
+#. --- Special Codes ---
+#: addon\globalPlugins\polyglot\common\languages.py:15
+#: addon\globalPlugins\polyglot\common\languages.py:16
+msgid "Auto-detect"
+msgstr "Tự động phát hiện"
+
+#. Used by Microsoft and Yandex
+#. --- Chinese Variants ---
+#: addon\globalPlugins\polyglot\common\languages.py:18
+#: addon\globalPlugins\polyglot\common\languages.py:28
+msgid "Chinese"
+msgstr "Tiếng Trung"
+
+#: addon\globalPlugins\polyglot\common\languages.py:19
+#: addon\globalPlugins\polyglot\common\languages.py:20
+#: addon\globalPlugins\polyglot\common\languages.py:21
+msgid "Chinese (Simplified)"
+msgstr "Tiếng Trung (Giản thể)"
+
+#. Lingva
+#: addon\globalPlugins\polyglot\common\languages.py:22
+#: addon\globalPlugins\polyglot\common\languages.py:23
+#: addon\globalPlugins\polyglot\common\languages.py:24
+#: addon\globalPlugins\polyglot\common\languages.py:25
+msgid "Chinese (Traditional)"
+msgstr "Tiếng Trung (Phồn thể)"
+
+#: addon\globalPlugins\polyglot\common\languages.py:26
+msgid "Cantonese"
+msgstr "Tiếng Quảng Đông"
+
+#: addon\globalPlugins\polyglot\common\languages.py:27
+msgid "Classical Chinese"
+msgstr "Tiếng Trung cổ phong / Văn ngôn"
+
+#. DeepL
+#. --- Major Languages ---
+#: addon\globalPlugins\polyglot\common\languages.py:30
+msgid "English"
+msgstr "Tiếng Anh"
+
+#: addon\globalPlugins\polyglot\common\languages.py:31
+#: addon\globalPlugins\polyglot\common\languages.py:32
+msgid "Japanese"
+msgstr "Tiếng Nhật"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:33
+#: addon\globalPlugins\polyglot\common\languages.py:34
+#: addon\globalPlugins\polyglot\common\languages.py:35
+msgid "Korean"
+msgstr "Tiếng Hàn"
+
+#. DeepL
+#: addon\globalPlugins\polyglot\common\languages.py:36
+#: addon\globalPlugins\polyglot\common\languages.py:37
+msgid "French"
+msgstr "Tiếng Pháp"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:38
+msgid "German"
+msgstr "Tiếng Đức"
+
+#: addon\globalPlugins\polyglot\common\languages.py:39
+#: addon\globalPlugins\polyglot\common\languages.py:40
+msgid "Spanish"
+msgstr "Tiếng Tây Ban Nha"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:41
+msgid "Russian"
+msgstr "Tiếng Nga"
+
+#: addon\globalPlugins\polyglot\common\languages.py:42
+msgid "Portuguese"
+msgstr "Tiếng Bồ Đào Nha"
+
+#: addon\globalPlugins\polyglot\common\languages.py:43
+msgid "Italian"
+msgstr "Tiếng Ý"
+
+#: addon\globalPlugins\polyglot\common\languages.py:44
+#: addon\globalPlugins\polyglot\common\languages.py:45
+msgid "Arabic"
+msgstr "Tiếng Ả Rập"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:46
+msgid "Achuar"
+msgstr "Tiếng Achuar"
+
+#: addon\globalPlugins\polyglot\common\languages.py:47
+msgid "Amharic"
+msgstr "Tiếng Amharic"
+
+#. --- Other European Languages ---
+#: addon\globalPlugins\polyglot\common\languages.py:49
+msgid "Dutch"
+msgstr "Tiếng Hà Lan"
+
+#: addon\globalPlugins\polyglot\common\languages.py:50
+#: addon\globalPlugins\polyglot\common\languages.py:51
+msgid "Swedish"
+msgstr "Tiếng Thụy Điển"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:52
+msgid "Polish"
+msgstr "Tiếng Ba Lan"
+
+#: addon\globalPlugins\polyglot\common\languages.py:53
+#: addon\globalPlugins\polyglot\common\languages.py:54
+msgid "Danish"
+msgstr "Tiếng Đan Mạch"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:55
+#: addon\globalPlugins\polyglot\common\languages.py:56
+msgid "Finnish"
+msgstr "Tiếng Phần Lan"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:57
+msgid "Norwegian"
+msgstr "Tiếng Na Uy"
+
+#: addon\globalPlugins\polyglot\common\languages.py:58
+msgid "Norwegian (Bokmål)"
+msgstr "Tiếng Na Uy (Bokmål)"
+
+#: addon\globalPlugins\polyglot\common\languages.py:59
+msgid "Norwegian (Nynorsk)"
+msgstr "Tiếng Na Uy (Nynorsk)"
+
+#: addon\globalPlugins\polyglot\common\languages.py:60
+msgid "Czech"
+msgstr "Tiếng Séc"
+
+#: addon\globalPlugins\polyglot\common\languages.py:61
+msgid "Slovak"
+msgstr "Tiếng Slovak"
+
+#: addon\globalPlugins\polyglot\common\languages.py:62
+msgid "Hungarian"
+msgstr "Tiếng Hungary"
+
+#: addon\globalPlugins\polyglot\common\languages.py:63
+#: addon\globalPlugins\polyglot\common\languages.py:64
+msgid "Romanian"
+msgstr "Tiếng Romania"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:65
+#: addon\globalPlugins\polyglot\common\languages.py:66
+msgid "Bulgarian"
+msgstr "Tiếng Bulgaria"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:67
+msgid "Greek"
+msgstr "Tiếng Hy Lạp"
+
+#: addon\globalPlugins\polyglot\common\languages.py:68
+msgid "Lithuanian"
+msgstr "Tiếng Litva"
+
+#: addon\globalPlugins\polyglot\common\languages.py:69
+msgid "Latvian"
+msgstr "Tiếng Latvia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:70
+#: addon\globalPlugins\polyglot\common\languages.py:71
+msgid "Estonian"
+msgstr "Tiếng Estonia"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:72
+#: addon\globalPlugins\polyglot\common\languages.py:73
+msgid "Slovenian"
+msgstr "Tiếng Slovenia"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:74
+msgid "Croatian"
+msgstr "Tiếng Croatia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:75
+msgid "Serbian"
+msgstr "Tiếng Serbia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:76
+msgid "Bosnian"
+msgstr "Tiếng Bosnia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:77
+msgid "Albanian"
+msgstr "Tiếng An-ba-ni"
+
+#: addon\globalPlugins\polyglot\common\languages.py:78
+msgid "Macedonian"
+msgstr "Tiếng Macedonia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:79
+msgid "Ukrainian"
+msgstr "Tiếng Ukraina"
+
+#: addon\globalPlugins\polyglot\common\languages.py:80
+msgid "Belarusian"
+msgstr "Tiếng Belarus"
+
+#: addon\globalPlugins\polyglot\common\languages.py:81
+msgid "Icelandic"
+msgstr "Tiếng Iceland"
+
+#: addon\globalPlugins\polyglot\common\languages.py:82
+msgid "Irish"
+msgstr "Tiếng Ireland"
+
+#: addon\globalPlugins\polyglot\common\languages.py:83
+msgid "Maltese"
+msgstr "Tiếng Malta"
+
+#: addon\globalPlugins\polyglot\common\languages.py:84
+msgid "Welsh"
+msgstr "Tiếng xứ Wales"
+
+#: addon\globalPlugins\polyglot\common\languages.py:85
+msgid "Basque"
+msgstr "Tiếng Basque"
+
+#: addon\globalPlugins\polyglot\common\languages.py:86
+msgid "Catalan"
+msgstr "Tiếng Catalan"
+
+#: addon\globalPlugins\polyglot\common\languages.py:87
+msgid "Galician"
+msgstr "Tiếng Galician"
+
+#: addon\globalPlugins\polyglot\common\languages.py:88
+msgid "Luxembourgish"
+msgstr "Tiếng Luxembourg"
+
+#: addon\globalPlugins\polyglot\common\languages.py:89
+msgid "Scots Gaelic"
+msgstr "Tiếng Gaelic Scotland"
+
+#. --- Other Asian & Middle Eastern Languages ---
+#: addon\globalPlugins\polyglot\common\languages.py:91
+msgid "Thai"
+msgstr "Tiếng Thái"
+
+#: addon\globalPlugins\polyglot\common\languages.py:92
+#: addon\globalPlugins\polyglot\common\languages.py:93
+msgid "Vietnamese"
+msgstr "Tiếng Việt"
+
+#. Baidu
+#: addon\globalPlugins\polyglot\common\languages.py:94
+msgid "Indonesian"
+msgstr "Tiếng Indonesia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:95
+msgid "Malay"
+msgstr "Tiếng Mã Lai"
+
+#: addon\globalPlugins\polyglot\common\languages.py:96
+msgid "Filipino"
+msgstr "Tiếng Phi-líp-pin"
+
+#: addon\globalPlugins\polyglot\common\languages.py:97
+msgid "Cebuano"
+msgstr "Tiếng Cebuano"
+
+#: addon\globalPlugins\polyglot\common\languages.py:98
+msgid "Myanmar (Burmese)"
+msgstr "Tiếng Miến Điện (Myanmar)"
+
+#: addon\globalPlugins\polyglot\common\languages.py:99
+msgid "Khmer"
+msgstr "Tiếng Khơ-me"
+
+#: addon\globalPlugins\polyglot\common\languages.py:100
+msgid "Lao"
+msgstr "Tiếng Lào"
+
+#: addon\globalPlugins\polyglot\common\languages.py:101
+msgid "Javanese"
+msgstr "Tiếng Java"
+
+#: addon\globalPlugins\polyglot\common\languages.py:102
+msgid "Sundanese"
+msgstr "Tiếng Sunda"
+
+#: addon\globalPlugins\polyglot\common\languages.py:103
+msgid "Hindi"
+msgstr "Tiếng Hindi"
+
+#: addon\globalPlugins\polyglot\common\languages.py:104
+msgid "Bengali"
+msgstr "Tiếng Bengali"
+
+#: addon\globalPlugins\polyglot\common\languages.py:105
+msgid "Punjabi"
+msgstr "Tiếng Punjabi"
+
+#: addon\globalPlugins\polyglot\common\languages.py:106
+msgid "Gujarati"
+msgstr "Tiếng Gujarati"
+
+#: addon\globalPlugins\polyglot\common\languages.py:107
+msgid "Marathi"
+msgstr "Tiếng Marathi"
+
+#: addon\globalPlugins\polyglot\common\languages.py:108
+msgid "Tamil"
+msgstr "Tiếng Tamil"
+
+#: addon\globalPlugins\polyglot\common\languages.py:109
+msgid "Telugu"
+msgstr "Tiếng Telugu"
+
+#: addon\globalPlugins\polyglot\common\languages.py:110
+msgid "Kannada"
+msgstr "Tiếng Kannada"
+
+#: addon\globalPlugins\polyglot\common\languages.py:111
+msgid "Malayalam"
+msgstr "Tiếng Malayalam"
+
+#: addon\globalPlugins\polyglot\common\languages.py:112
+msgid "Sinhala"
+msgstr "Tiếng Sinhala"
+
+#: addon\globalPlugins\polyglot\common\languages.py:113
+msgid "Nepali"
+msgstr "Tiếng Nepal"
+
+#: addon\globalPlugins\polyglot\common\languages.py:114
+msgid "Sindhi"
+msgstr "Tiếng Sindhi"
+
+#: addon\globalPlugins\polyglot\common\languages.py:115
+msgid "Persian"
+msgstr "Tiếng Ba Tư"
+
+#: addon\globalPlugins\polyglot\common\languages.py:116
+#: addon\globalPlugins\polyglot\common\languages.py:117
+msgid "Hebrew"
+msgstr "Tiếng Do Thái"
+
+#. Chrome Translator API
+#: addon\globalPlugins\polyglot\common\languages.py:118
+msgid "Turkish"
+msgstr "Tiếng Thổ Nhĩ Kỳ"
+
+#: addon\globalPlugins\polyglot\common\languages.py:119
+msgid "Azerbaijani"
+msgstr "Tiếng Azerbaijan"
+
+#: addon\globalPlugins\polyglot\common\languages.py:120
+msgid "Armenian"
+msgstr "Tiếng Armenia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:121
+msgid "Georgian"
+msgstr "Tiếng Gruzia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:122
+msgid "Uzbek"
+msgstr "Tiếng Uzbek"
+
+#: addon\globalPlugins\polyglot\common\languages.py:123
+msgid "Kazakh"
+msgstr "Tiếng Kazakh"
+
+#: addon\globalPlugins\polyglot\common\languages.py:124
+msgid "Kyrgyz"
+msgstr "Tiếng Kyrgyz"
+
+#: addon\globalPlugins\polyglot\common\languages.py:125
+msgid "Tajik"
+msgstr "Tiếng Tajik"
+
+#: addon\globalPlugins\polyglot\common\languages.py:126
+msgid "Urdu"
+msgstr "Tiếng Urdu"
+
+#: addon\globalPlugins\polyglot\common\languages.py:127
+msgid "Pashto"
+msgstr "Tiếng Pashto"
+
+#: addon\globalPlugins\polyglot\common\languages.py:128
+msgid "Kurdish"
+msgstr "Tiếng Kurd"
+
+#: addon\globalPlugins\polyglot\common\languages.py:129
+msgid "Mongolian (Cyrillic)"
+msgstr "Tiếng Mông Cổ (Chữ Cyrillic)"
+
+#: addon\globalPlugins\polyglot\common\languages.py:130
+msgid "Mongolian (Traditional)"
+msgstr "Tiếng Mông Cổ (Chữ truyền thống)"
+
+#: addon\globalPlugins\polyglot\common\languages.py:131
+msgid "Hmong"
+msgstr "Tiếng H'Mông"
+
+#. --- African Languages ---
+#: addon\globalPlugins\polyglot\common\languages.py:133
+msgid "Afrikaans"
+msgstr "Tiếng Afrikaans"
+
+#: addon\globalPlugins\polyglot\common\languages.py:134
+msgid "Swahili"
+msgstr "Tiếng Swahili"
+
+#: addon\globalPlugins\polyglot\common\languages.py:135
+msgid "Somali"
+msgstr "Tiếng Somali"
+
+#: addon\globalPlugins\polyglot\common\languages.py:136
+msgid "Hausa"
+msgstr "Tiếng Hausa"
+
+#: addon\globalPlugins\polyglot\common\languages.py:137
+msgid "Yoruba"
+msgstr "Tiếng Yoruba"
+
+#: addon\globalPlugins\polyglot\common\languages.py:138
+msgid "Igbo"
+msgstr "Tiếng Igbo"
+
+#: addon\globalPlugins\polyglot\common\languages.py:139
+msgid "Zulu"
+msgstr "Tiếng Zulu"
+
+#: addon\globalPlugins\polyglot\common\languages.py:140
+msgid "Xhosa"
+msgstr "Tiếng Xhosa"
+
+#: addon\globalPlugins\polyglot\common\languages.py:141
+msgid "Sesotho"
+msgstr "Tiếng Sesotho"
+
+#: addon\globalPlugins\polyglot\common\languages.py:142
+msgid "Shona"
+msgstr "Tiếng Shona"
+
+#: addon\globalPlugins\polyglot\common\languages.py:143
+msgid "Malagasy"
+msgstr "Tiếng Malagasy"
+
+#: addon\globalPlugins\polyglot\common\languages.py:144
+msgid "Chichewa"
+msgstr "Tiếng Chichewa"
+
+#. --- Oceanic & Constructed Languages ---
+#: addon\globalPlugins\polyglot\common\languages.py:146
+msgid "Maori"
+msgstr "Tiếng Maori"
+
+#: addon\globalPlugins\polyglot\common\languages.py:147
+msgid "Samoan"
+msgstr "Tiếng Samoa"
+
+#: addon\globalPlugins\polyglot\common\languages.py:148
+msgid "Haitian Creole"
+msgstr "Tiếng Creole Haiti"
+
+#: addon\globalPlugins\polyglot\common\languages.py:149
+msgid "Hawaiian"
+msgstr "Tiếng Hawaii"
+
+#: addon\globalPlugins\polyglot\common\languages.py:150
+msgid "Corsican"
+msgstr "Tiếng Corsica"
+
+#: addon\globalPlugins\polyglot\common\languages.py:151
+msgid "Frisian"
+msgstr "Tiếng Frisia"
+
+#: addon\globalPlugins\polyglot\common\languages.py:152
+msgid "Yiddish"
+msgstr "Tiếng Yiddish"
+
+#: addon\globalPlugins\polyglot\common\languages.py:153
+msgid "Esperanto"
+msgstr "Tiếng Esperanto"
+
+#: addon\globalPlugins\polyglot\common\languages.py:154
+msgid "Latin"
+msgstr "Tiếng La-tinh"
+
+#: addon\globalPlugins\polyglot\common\network.py:74
+#, python-brace-format
+msgid ""
+"Service temporarily unavailable or timed out. Please try again later. (HTTP "
+"{code})"
+msgstr ""
+"Dịch vụ tạm thời không khả dụng hoặc quá thời gian chờ. Vui lòng thử lại "
+"sau. (Mã lỗi HTTP: {code})"
+
+#: addon\globalPlugins\polyglot\common\network.py:79
+msgid "Request to translation service timed out"
+msgstr "Yêu cầu đến dịch vụ dịch thuật đã quá thời gian chờ"
+
+#: addon\globalPlugins\polyglot\common\network.py:84
+#, python-brace-format
+msgid "Network connection error: {error}"
+msgstr "Lỗi kết nối mạng: {error}"
+
+#: addon\globalPlugins\polyglot\common\network.py:130
+msgid "Authentication failed. Please check your API key."
+msgstr "Xác thực thất bại. Vui lòng kiểm tra lại khóa API của bạn."
+
+#: addon\globalPlugins\polyglot\common\network.py:132
+msgid "Monthly translation quota has been reached."
+msgstr "Đã đạt đến hạn ngạch dịch thuật hàng tháng."
+
+#: addon\globalPlugins\polyglot\common\network.py:137
+#, python-brace-format
+msgid "Service returned an error: {code} {reason}. Details: {details}"
+msgstr "Dịch vụ báo lỗi: {code} {reason}. Chi tiết: {details}"
+
+#: addon\globalPlugins\polyglot\modelManager\catalog.py:154
+msgid "Bundled model catalog is missing."
+msgstr "Danh mục mô hình đi kèm add-on (Bundled catalog) bị thiếu."
+
+#: addon\globalPlugins\polyglot\modelManager\catalog.py:161
+msgid "Catalog JSON is empty."
+msgstr "Tệp JSON danh mục đang trống."
+
+#: addon\globalPlugins\polyglot\modelManager\catalog.py:164
+msgid "Catalog JSON is invalid."
+msgstr "Tệp JSON danh mục không hợp lệ."
+
+#: addon\globalPlugins\polyglot\modelManager\catalog.py:170
+#, python-brace-format
+msgid "Unsupported catalog schema version: {version}"
+msgstr ""
+"Phiên bản cấu trúc danh mục (Schema version) không được hỗ trợ: {version}"
+
+#: addon\globalPlugins\polyglot\modelManager\catalog.py:181
+#, python-brace-format
+msgid "Duplicate model package key in catalog: {key}"
+msgstr "Trùng lặp khóa gói mô hình trong danh mục: {key}"
+
+#: addon\globalPlugins\polyglot\modelManager\catalog.py:240
+msgid "Catalog URL must be an HTTP or HTTPS URL."
+msgstr "Đường dẫn URL danh mục phải là định dạng HTTP hoặc HTTPS."
+
+#: addon\globalPlugins\polyglot\modelManager\catalog.py:286
+#, python-brace-format
+msgid "{source} / {target}"
+msgstr "{source} / {target}"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:91
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:266
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:293
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:382
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:486
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:594
+#: addon\globalPlugins\polyglot\modelManager\service.py:221
+#: addon\globalPlugins\polyglot\modelManager\service.py:246
+#: addon\globalPlugins\polyglot\modelManager\service.py:276
+msgid "Polyglot ChromeAI Model Manager"
+msgstr "Trình quản lý mô hình ChromeAI Polyglot"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:127
+msgid ""
+"Models: check a model to install it; uncheck an installed model to remove it."
+msgstr ""
+"Mô hình: tích chọn để cài đặt; bỏ chọn đối với mô hình đã cài đặt để gỡ bỏ."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:139
+msgid "Language"
+msgstr "Ngôn ngữ"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:140
+msgid "Status"
+msgstr "Trạng thái"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:141
+msgid "Size"
+msgstr "Dung lượng"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:142
+msgid "Version"
+msgstr "Phiên bản"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:154
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:553
+#, python-brace-format
+msgid "Apply changes ({count})"
+msgstr "Áp dụng các thay đổi ({count})"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:155
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:560
+msgid "Advanced"
+msgstr "Nâng cao"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:167
+msgid "Log"
+msgstr "Nhật ký lỗi (Log)"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:187
+msgid "Catalog URL:"
+msgstr "Đường dẫn danh mục (Catalog URL):"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:192
+msgid "Restore default"
+msgstr "Khôi phục mặc định"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:200
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:344
+msgid "Catalog: not loaded"
+msgstr "Danh mục: Chưa tải"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:203
+#, python-brace-format
+msgid "Install target: {path}"
+msgstr "Thư mục cài đặt đích: {path}"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:205
+msgid "Status: idle"
+msgstr "Trạng thái: Đang rảnh"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:210
+msgid "Load catalog"
+msgstr "Tải danh mục"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:211
+msgid "Open target"
+msgstr "Mở thư mục đích"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:213
+msgid "Open temp downloads"
+msgstr "Mở thư mục tải xuống tạm thời"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:265
+msgid "A model operation is still running."
+msgstr "Một tiến trình xử lý mô hình hiện đang chạy."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:292
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:591
+msgid "Failed."
+msgstr "Thất bại."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:296
+#, python-brace-format
+msgid "Loading catalog: {url}"
+msgstr "Đang tải danh mục: {url}"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:305
+#, python-brace-format
+msgid "Catalog: remote; generated {generatedAt}"
+msgstr "Danh mục: Máy chủ từ xa; được tạo lúc {generatedAt}"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:311
+#, python-brace-format
+msgid "Remote catalog failed: {error}"
+msgstr "Tải danh mục từ xa thất bại: {error}"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:315
+#, python-brace-format
+msgid "Catalog: bundled fallback; generated {generatedAt}"
+msgstr "Danh mục: Sử dụng tệp đi kèm dự phòng; được tạo lúc {generatedAt}"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:330
+msgid "Catalog: failed to load"
+msgstr "Danh mục: Không thể tải"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:339
+#, python-brace-format
+msgid "Loaded {count} model package(s)."
+msgstr "Đã tải {count} gói mô hình."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:346
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:389
+#: addon\globalPlugins\polyglot\modelManager\service.py:245
+msgid "Another model operation is already running."
+msgstr "Một tiến trình xử lý mô hình khác hiện đang chạy."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:367
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:368
+msgid "Changes applied."
+msgstr "Đã áp dụng các thay đổi."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:379
+#, python-brace-format
+msgid ""
+"This will delete {size:.1f} MiB of temporary and legacy cached downloads. "
+"Installed models will not be removed.\n"
+"\n"
+"Continue?"
+msgstr ""
+"Hành động này sẽ xóa {size:.1f} MiB tệp tải xuống tạm thời và bộ nhớ đệm cũ. "
+"Các mô hình đã cài đặt sẽ không bị ảnh hưởng.\n"
+"\n"
+"Tiếp tục chứ?"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:409
+msgid "Temporary downloads are empty."
+msgstr "Thư mục tải xuống tạm thời đang trống."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:411
+#: addon\globalPlugins\polyglot\modelManager\installer.py:121
+#, python-brace-format
+msgid "Cleared temporary downloads ({size:.1f} MiB)."
+msgstr "Đã xóa các tệp tải xuống tạm thời ({size:.1f} MiB)."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:433
+msgid "installed"
+msgstr "đã cài đặt"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:433
+msgid "not installed"
+msgstr "chưa cài đặt"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:441
+#, python-brace-format
+msgid "{count} installed package(s) detected."
+msgstr "Phát hiện {count} gói đã được cài đặt."
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:459
+#, python-brace-format
+msgid "{size:.1f} MiB"
+msgstr "{size:.1f} MiB"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:483
+#, python-brace-format
+msgid ""
+"The following installed model package(s) will be removed:\n"
+"\n"
+"{names}\n"
+"\n"
+"Continue?"
+msgstr ""
+"Các gói mô hình đã cài đặt sau đây sẽ bị gỡ bỏ:\n"
+"\n"
+"{names}\n"
+"\n"
+"Tiếp tục chứ?"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:503
+#, python-brace-format
+msgid ""
+"Selected: {selected} | Install: {install} | Remove: {remove} | Cleanup: "
+"{cleanup}"
+msgstr ""
+"Đang chọn: {selected} | Cài đặt: {install} | Gỡ bỏ: {remove} | Dọn dẹp: "
+"{cleanup}"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:560
+msgid "Hide advanced"
+msgstr "Ẩn nâng cao"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:565
+#, python-brace-format
+msgid "Status: {message}"
+msgstr "Trạng thái: {message}"
+
+#: addon\globalPlugins\polyglot\modelManager\dialog.py:602
+#, python-brace-format
+msgid "Settings could not be saved: {error}"
+msgstr "Không thể lưu cài đặt: {error}"
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:141
+msgid "No model packages selected."
+msgstr "Chưa chọn gói mô hình nào."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:145
+#, python-brace-format
+msgid "Unknown package key: {key}"
+msgstr "Khóa gói (Package key) không xác định: {key}"
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:175
+msgid "TranslateKit runtime already installed."
+msgstr "Môi trường thực thi (runtime) TranslateKit đã được cài đặt."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:180
+msgid "TranslateKit runtime does not have a downloadable archive."
+msgstr ""
+"Môi trường thực thi TranslateKit không có tệp nén lưu trữ để tải xuống."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:181
+msgid "Installing downloaded TranslateKit runtime."
+msgstr "Đang cài đặt môi trường thực thi TranslateKit đã tải xuống."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:203
+#, python-brace-format
+msgid "{package} already installed."
+msgstr "{package} đã được cài đặt."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:210
+#, python-brace-format
+msgid "{package} does not have a downloadable archive."
+msgstr "{package} không có tệp nén lưu trữ để tải xuống."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:246
+#, python-brace-format
+msgid "Using cached archive {fileName}."
+msgstr "Đang sử dụng tệp lưu trữ trong bộ nhớ đệm {fileName}."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:251
+#: addon\globalPlugins\polyglot\modelManager\installer.py:467
+#, python-brace-format
+msgid "Downloading {fileName}."
+msgstr "Đang tải xuống {fileName}."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:255
+#, python-brace-format
+msgid "Downloaded archive verification failed: {fileName}"
+msgstr "Xác thực tệp lưu trữ đã tải xuống thất bại: {fileName}"
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:278
+#, python-brace-format
+msgid "Archive entry is outside the install root: {entry}"
+msgstr "Thành phần tệp nén nằm ngoài thư mục gốc cài đặt: {entry}"
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:286
+#, python-brace-format
+msgid "Extracting {fileName}."
+msgstr "Đang giải nén {fileName}."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:294
+#, python-brace-format
+msgid "Removed {package}."
+msgstr "Đã gỡ bỏ {package}."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:326
+#, python-brace-format
+msgid "Removed TranslateKit runtime ({size:.1f} MiB)."
+msgstr "Đã gỡ bỏ môi trường thực thi TranslateKit ({size:.1f} MiB)."
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:445
+#, python-brace-format
+msgid "Archive path has no file name: {path}"
+msgstr "Đường dẫn tệp nén không có tên tệp tin: {path}"
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:604
+#, python-brace-format
+msgid ""
+"Some model files are currently being used and cannot be replaced or "
+"removed.\n"
+"\n"
+"Please manually disable the {engine} translation engine, restart NVDA, and "
+"then try again.\n"
+"\n"
+"Error: {error}"
+msgstr ""
+"Một số tệp mô hình hiện đang được sử dụng nên không thể thay thế hoặc gỡ "
+"bỏ.\n"
+"\n"
+"Vui lòng tắt bộ dịch {engine} thủ công, khởi động lại NVDA rồi thử lại.\n"
+"\n"
+"Lỗi: {error}"
+
+#: addon\globalPlugins\polyglot\modelManager\installer.py:607
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:33
+msgid "Chrome AI (Offline)"
+msgstr "Chrome AI (Ngoại tuyến)"
+
+#: addon\globalPlugins\polyglot\modelManager\menu.py:75
+msgid "Polyglot ChromeAI model manager"
+msgstr "Trình quản lý mô hình ChromeAI Polyglot"
+
+#: addon\globalPlugins\polyglot\modelManager\menu.py:76
+msgid "Manage Polyglot ChromeAI offline translation models"
+msgstr "Quản lý các mô hình dịch thuật ngoại tuyến ChromeAI của Polyglot"
+
+#: addon\globalPlugins\polyglot\modelManager\service.py:209
+#, python-brace-format
+msgid ""
+"The following offline model package(s) are not installed:\n"
+"\n"
+"{packages}\n"
+"\n"
+"Choose Yes to download and install them with Polyglot's model manager. Use "
+"this if Chrome's model download service is slow, blocked, or unreliable on "
+"your network.\n"
+"Choose No to let Chrome download them.\n"
+"Choose Cancel to cancel this translation."
+msgstr ""
+"Các gói mô hình ngoại tuyến sau đây chưa được cài đặt:\n"
+"\n"
+"{packages}\n"
+"\n"
+"Chọn Yes để tải xuống và cài đặt thông qua trình quản lý mô hình của "
+"Polyglot. Hãy dùng cách này nếu dịch vụ tải mô hình của Chrome quá chậm, bị "
+"chặn hoặc không ổn định trên mạng của bạn.\n"
+"Chọn No để mặc định cho Chrome tự tải xuống.\n"
+"Chọn Cancel để hủy lệnh dịch này."
+
+#: addon\globalPlugins\polyglot\modelManager\service.py:264
+msgid "Model installation complete."
+msgstr "Quá trình cài đặt mô hình đã hoàn tất."
+
+#: addon\globalPlugins\polyglot\services\engine.py:58
+msgid "Enable this engine"
+msgstr "Bật bộ dịch này"
+
+#: addon\globalPlugins\polyglot\services\engine.py:242
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:122
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:46
+msgid "Source language:"
+msgstr "Ngôn ngữ nguồn:"
+
+#: addon\globalPlugins\polyglot\services\engine.py:249
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:129
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:47
+msgid "Target language:"
+msgstr "Ngôn ngữ đích:"
+
+#: addon\globalPlugins\polyglot\services\engine.py:260
+msgid "Proxy mode:"
+msgstr "Chế độ Proxy:"
+
+#: addon\globalPlugins\polyglot\services\engine.py:263
+msgid "Use system proxy settings"
+msgstr "Sử dụng cấu hình proxy của hệ thống"
+
+#: addon\globalPlugins\polyglot\services\engine.py:264
+msgid "Do not use proxy"
+msgstr "Không sử dụng proxy"
+
+#: addon\globalPlugins\polyglot\services\engine.py:270
+msgid "Request timeout:"
+msgstr "Thời gian chờ yêu cầu:"
+
+#: addon\globalPlugins\polyglot\services\engine.py:286
+msgid ""
+"Auto-swap if detected source matches target (source must be 'Auto-detect')"
+msgstr ""
+"Tự động hoán đổi nếu ngôn ngữ nguồn phát hiện được trùng với ngôn ngữ đích "
+"(ngôn ngữ nguồn phải là 'Tự động phát hiện')"
+
+#: addon\globalPlugins\polyglot\services\engine.py:293
+msgid "Swap to language:"
+msgstr "Hoán đổi sang ngôn ngữ:"
+
+#: addon\globalPlugins\polyglot\services\engine.py:389
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:195
+msgid "Failed to parse response from translation service."
+msgstr "Không thể phân tích phản hồi từ dịch vụ dịch thuật."
+
+#: addon\globalPlugins\polyglot\services\engine.py:394
+#: addon\globalPlugins\polyglot\services\engines\microsoft.py:163
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:200
+msgid "An unknown error occurred during translation."
+msgstr "Đã xảy ra lỗi không xác định trong quá trình dịch."
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:23
+msgid "Baidu Translate"
+msgstr "Baidu Translate"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:27
+msgid "Request timed out"
+msgstr "Yêu cầu quá thời gian chờ"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:28
+msgid "System error"
+msgstr "Lỗi hệ thống"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:29
+msgid ""
+"Unauthorized user. Please check your App ID or if the service is enabled."
+msgstr ""
+"Người dùng chưa được cấp quyền. Vui lòng kiểm tra lại App ID hoặc xem dịch "
+"vụ đã được bật chưa."
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:30
+msgid "Required parameter is missing"
+msgstr "Thiếu tham số bắt buộc"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:31
+msgid "Signature error. Please check your App Secret."
+msgstr "Lỗi chữ ký xác thực. Vui lòng kiểm tra lại App Secret."
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:32
+msgid "Access frequency limited"
+msgstr "Tần suất truy cập bị giới hạn"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:33
+msgid "Insufficient account balance"
+msgstr "Số dư tài khoản không đủ"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:34
+msgid "Frequent long query requests"
+msgstr "Yêu cầu truy vấn dài quá thường xuyên"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:35
+msgid "Invalid client IP"
+msgstr "IP máy khách không hợp lệ"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:36
+msgid ""
+"Translation direction not supported (may be due to insufficient permissions)"
+msgstr "Hướng dịch không được hỗ trợ (có thể do không đủ quyền hạn)"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:37
+msgid "Service is currently disabled"
+msgstr "Dịch vụ hiện đang bị tắt"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:38
+msgid "IP has been blocked"
+msgstr "Địa chỉ IP đã bị chặn"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:39
+msgid "Authentication failed or has not taken effect"
+msgstr "Xác thực thất bại hoặc chưa có hiệu lực"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:40
+msgid "Request content poses a security risk"
+msgstr "Nội dung yêu cầu có nguy cơ rủi ro bảo mật"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:65
+msgid ""
+"Use custom terminology (requires authentication and configuration on the "
+"platform)"
+msgstr ""
+"Sử dụng thuật ngữ tùy chỉnh (yêu cầu xác thực và cấu hình trên nền tảng)"
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:116
+msgid "App ID and App Secret are required."
+msgstr "Yêu cầu phải có App ID và App Secret."
+
+#: addon\globalPlugins\polyglot\services\engines\baidu.py:144
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:166
+#: addon\globalPlugins\polyglot\services\engines\tencentPolyglot.py:96
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:110
+#: addon\globalPlugins\polyglot\services\engines\volcenginePolyglot.py:104
+msgid "Unknown API error"
+msgstr "Lỗi API không xác định"
+
+#: addon\globalPlugins\polyglot\services\engines\caiyun.py:27
+msgid "Caiyun"
+msgstr "Caiyun"
+
+#: addon\globalPlugins\polyglot\services\engines\caiyun.py:65
+msgid "Authentication Token"
+msgstr "Mã xác thực (Token)"
+
+#: addon\globalPlugins\polyglot\services\engines\caiyun.py:74
+msgid "Authentication Token for Caiyun is not configured."
+msgstr "Mã xác thực cho Caiyun chưa được cấu hình."
+
+#: addon\globalPlugins\polyglot\services\engines\caiyun.py:107
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:185
+#: addon\globalPlugins\polyglot\services\engines\microsoft.py:223
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:247
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:180
+#: addon\globalPlugins\polyglot\services\engines\yandex.py:130
+msgid "Invalid API response or no translation result included."
+msgstr "Phản hồi API không hợp lệ hoặc không bao gồm kết quả dịch."
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:104
+msgid ""
+"Enable Chrome AI offline engine (requires Chrome 138+, resources released on "
+"NVDA exit)"
+msgstr ""
+"Bật bộ dịch ngoại tuyến Chrome AI (yêu cầu Chrome 138+, tài nguyên sẽ được "
+"giải phóng khi thoát NVDA)"
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:202
+msgid ""
+"Chrome AI offline engine is disabled. Enable it in the Polyglot settings "
+"panel before using it."
+msgstr ""
+"Bộ dịch ngoại tuyến Chrome AI đang bị tắt. Hãy bật nó trong bảng cài đặt "
+"Polyglot trước khi sử dụng."
+
+#. Translators: {model} is a model name like "Translation model".
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:242
+#, python-brace-format
+msgid "Preparing {model}..."
+msgstr "Đang chuẩn bị {model}..."
+
+#. Translators: Announced when Chrome has finished preparing an offline model.
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:254
+msgid "Model ready."
+msgstr "Mô hình đã sẵn sàng."
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:389
+msgid "Translation model"
+msgstr "Mô hình dịch thuật"
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:395
+msgid "Unexpected Chrome AI error: "
+msgstr "Lỗi Chrome AI không mong muốn: "
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:416
+msgid ""
+"Chrome's Translator API is not available. Please update Chrome to version "
+"138 or later and ensure the TranslationAPI flag is enabled in chrome://flags."
+msgstr ""
+"Translator API của Chrome không khả dụng. Vui lòng cập nhật Chrome lên phiên "
+"bản 138 hoặc mới hơn và đảm bảo flag TranslationAPI đã được bật trong "
+"chrome://flags."
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:425
+msgid ""
+"Chrome AI must run in a secure page context. Please restart NVDA and try the "
+"Chrome AI engine again."
+msgstr ""
+"Chrome AI phải chạy trong ngữ cảnh trang bảo mật. Vui lòng khởi động lại "
+"NVDA và thử lại bộ dịch Chrome AI."
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:436
+msgid "Chrome AI error: "
+msgstr "Lỗi Chrome AI: "
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:436
+msgid "Unknown error"
+msgstr "Lỗi không xác định"
+
+#: addon\globalPlugins\polyglot\services\engines\chromeAi.py:438
+msgid "Chrome AI returned an unexpected response."
+msgstr "Chrome AI trả về một phản hồi không mong muốn."
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:21
+msgid "DeepL"
+msgstr "DeepL"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:43
+msgid "API Key (Auth Key)"
+msgstr "Khóa API (Mã xác thực)"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:44
+msgid "Use Free API"
+msgstr "Sử dụng API miễn phí"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:45
+msgid "Context (optional):"
+msgstr "Ngữ cảnh (không bắt buộc):"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:48
+msgid "Sentence splitting mode:"
+msgstr "Chế độ tách câu:"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:51
+msgid "On (split at punctuation and newlines)"
+msgstr "Bật (ngắt tại dấu câu và xuống dòng)"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:52
+msgid "Off (no splitting)"
+msgstr "Tắt (không ngắt câu)"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:53
+msgid "Only at punctuation"
+msgstr "Chỉ ngắt tại dấu câu"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:59
+msgid "Preserve formatting"
+msgstr "Giữ nguyên định dạng"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:65
+msgid "Formality (for supported languages):"
+msgstr "Mức độ trang trọng (cho các ngôn ngữ được hỗ trợ):"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:68
+msgid "Default"
+msgstr "Mặc định"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:69
+msgid "More formal"
+msgstr "Trang trọng hơn"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:70
+msgid "Less formal"
+msgstr "Thân mật hơn"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:76
+msgid "Model type:"
+msgstr "Loại mô hình:"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:79
+msgid "Speed-optimized (default)"
+msgstr "Tối ưu tốc độ (mặc định)"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:80
+msgid "Quality-optimized"
+msgstr "Tối ưu chất lượng"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:81
+msgid "Prefer quality-optimized model"
+msgstr "Ưu tiên mô hình tối ưu chất lượng"
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:133
+msgid "DeepL API Key (Auth Key) is not configured."
+msgstr "Khóa DeepL API (Mã xác thực) chưa được cấu hình."
+
+#: addon\globalPlugins\polyglot\services\engines\deepl.py:138
+msgid ""
+"You have selected the Pro API, but the provided key is for the Free API. "
+"Please check 'Use Free API' in settings."
+msgstr ""
+"Bạn đã chọn API trả phí (Pro), nhưng khóa được cung cấp lại dành cho API "
+"miễn phí. Vui lòng tích chọn 'Sử dụng API miễn phí' trong phần cài đặt."
+
+#: addon\globalPlugins\polyglot\services\engines\google.py:17
+msgid "Google Translate (key-free)"
+msgstr "Google Translate (không cần khóa)"
+
+#: addon\globalPlugins\polyglot\services\engines\google.py:45
+msgid "Use mirror server (translate.googleapis.mirror.nvdadr.com)"
+msgstr "Sử dụng máy chủ gương (translate.googleapis.mirror.nvdadr.com)"
+
+#: addon\globalPlugins\polyglot\services\engines\googlePolyglot.py:22
+msgid "Google Translate (Polyglot)"
+msgstr "Google Translate (Polyglot)"
+
+#: addon\globalPlugins\polyglot\services\engines\googlePolyglot.py:147
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:107
+msgid "API Key"
+msgstr "Khóa API (API Key)"
+
+#: addon\globalPlugins\polyglot\services\engines\googlePolyglot.py:153
+msgid "Endpoint URL"
+msgstr "Đường dẫn Endpoint"
+
+#: addon\globalPlugins\polyglot\services\engines\googlePolyglot.py:164
+msgid "API Key for Google Translate (HQ) is not configured."
+msgstr "Khóa API cho Google Translate (HQ) chưa được cấu hình."
+
+#: addon\globalPlugins\polyglot\services\engines\googlePolyglot.py:198
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:225
+msgid "Failed to parse API response."
+msgstr "Không thể phân tích phản hồi từ API."
+
+#: addon\globalPlugins\polyglot\services\engines\googlePolyglot.py:207
+msgid "Invalid API response or no translation text included."
+msgstr "Phản hồi API không hợp lệ hoặc không bao gồm văn bản dịch."
+
+#: addon\globalPlugins\polyglot\services\engines\lingva.py:28
+msgid "Lingva Translate"
+msgstr "Lingva Translate"
+
+#. Sometimes Lingva might return a non-JSON error for very long texts
+#: addon\globalPlugins\polyglot\services\engines\lingva.py:111
+msgid "Service returned an invalid result (text may be too long)."
+msgstr "Dịch vụ trả về kết quả không hợp lệ (văn bản có thể quá dài)."
+
+#: addon\globalPlugins\polyglot\services\engines\microsoft.py:36
+msgid "Microsoft Translator (key-free)"
+msgstr "Microsoft Translator (không cần khóa)"
+
+#: addon\globalPlugins\polyglot\services\engines\microsoft.py:121
+msgid "Could not get Microsoft Translator authentication token."
+msgstr "Không thể lấy mã token xác thực từ Microsoft Translator."
+
+#: addon\globalPlugins\polyglot\services\engines\microsoft.py:202
+msgid "Failed to parse response from Microsoft Translator."
+msgstr "Không thể phân tích phản hồi từ Microsoft Translator."
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:34
+msgid "Niutrans"
+msgstr "Niutrans"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:40
+msgid "Request address does not exist"
+msgstr "Địa chỉ yêu cầu không tồn tại"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:41
+msgid "Request is too frequent, exceeding QPS limit"
+msgstr "Yêu cầu quá thường xuyên, vượt quá giới hạn số yêu cầu mỗi giây (QPS)"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:42
+msgid "Request string length exceeds the limit"
+msgstr "Độ dài chuỗi yêu cầu vượt quá giới hạn"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:43
+msgid "Source language encoding is not UTF-8"
+msgstr "Mã hóa ngôn ngữ nguồn không phải là UTF-8"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:44
+msgid "Insufficient character allowance or no access permission"
+msgstr "Hạn ngạch ký tự không đủ hoặc không có quyền truy cập"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:45
+msgid "Content filtering exception"
+msgstr "Ngoại lệ trong quá trình lọc nội dung"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:46
+msgid "Source and target languages are the same"
+msgstr "Ngôn ngữ nguồn và ngôn ngữ đích giống nhau"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:47
+msgid "Language not supported"
+msgstr "Ngôn ngữ không được hỗ trợ"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:48
+msgid "Request processing timeout"
+msgstr "Xử lý yêu cầu quá thời gian chờ"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:49
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:171
+msgid "Authentication failed"
+msgstr "Xác thực thất bại"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:50
+msgid "Parameters do not conform to specifications"
+msgstr "Các tham số không đúng quy cách"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:52
+msgid ""
+"Parameter validation exception (e.g., from/to/srcText/appId/authStr/"
+"timestamp cannot be empty)"
+msgstr ""
+"Ngoại lệ xác thực tham số (ví dụ: các trường từ/đến/văn bản nguồn/appId/"
+"authStr/dấu thời gian không được để trống)"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:54
+msgid "Incorrect request parameters"
+msgstr "Tham số yêu cầu không chính xác"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:55
+msgid "Unsupported parameter passing method"
+msgstr "Phương thức truyền tham số không được hỗ trợ"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:90
+msgid "App ID"
+msgstr "App ID"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:91
+msgid "API Key (for signing)"
+msgstr "Khóa API (dùng để ký xác thực)"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:94
+msgid "Enable bilingual alignment mode"
+msgstr "Bật chế độ đối chiếu song ngữ"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:101
+msgid "Bilingual output order:"
+msgstr "Thứ tự xuất song ngữ:"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:104
+msgid "Source -> Target"
+msgstr "Nguồn -> Đích"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:105
+msgid "Target -> Source"
+msgstr "Đích -> Nguồn"
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:143
+msgid "App ID and API Key for Niutrans must be configured."
+msgstr "App ID và API Key cho Niutrans phải được cấu hình."
+
+#: addon\globalPlugins\polyglot\services\engines\niutrans.py:207
+msgid "Failed to parse API response. Response was not valid JSON."
+msgstr ""
+"Không thể phân tích phản hồi API. Phản hồi không phải là định dạng JSON hợp "
+"lệ."
+
+#: addon\globalPlugins\polyglot\services\engines\ollama1.py:17
+msgid "Ollama 1"
+msgstr "Ollama 1"
+
+#: addon\globalPlugins\polyglot\services\engines\ollama2.py:17
+msgid "Ollama 2"
+msgstr "Ollama 2"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:85
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:103
+msgid "API URL"
+msgstr "Đường dẫn API URL"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:89
+msgid "Model Name"
+msgstr "Tên mô hình"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:90
+msgid "API Key (optional)"
+msgstr "Khóa API (không bắt buộc)"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:93
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:123
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:55
+msgid "Prompt Template:"
+msgstr "Mẫu lời nhắc (Prompt Template):"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:96
+msgid "Simple (No JSON)"
+msgstr "Đơn giản (Không dùng JSON)"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:97
+msgid "Concise JSON (Recommended)"
+msgstr "JSON ngắn gọn (Khuyên dùng)"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:98
+msgid "Structured JSON (Reliable)"
+msgstr "JSON có cấu trúc (Đáng tin cậy)"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:99
+msgid "Fluent Style (No JSON)"
+msgstr "Phong cách trôi chảy (Không dùng JSON)"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:100
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:129
+msgid "Custom (Editable)"
+msgstr "Tùy chỉnh (Có thể chỉnh sửa)"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:106
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:135
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:56
+msgid "Custom System Prompt (Role):"
+msgstr "Lời nhắc hệ thống tùy chỉnh (Vai trò):"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:112
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:141
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:57
+msgid "Custom User Prompt (Task):"
+msgstr "Lời nhắc người dùng tùy chỉnh (Nhiệm vụ):"
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:132
+msgid "Ollama API URL and Model Name are required."
+msgstr "Yêu cầu phải có Ollama API URL và Tên mô hình."
+
+#: addon\globalPlugins\polyglot\services\engines\ollamaBase.py:187
+msgid "API response did not contain a 'response' field."
+msgstr "Phản hồi từ API không có trường 'response'."
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:23
+msgid "OpenRouter"
+msgstr "OpenRouter"
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:46
+msgid "Custom Model"
+msgstr "Mô hình tùy chỉnh"
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:110
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:54
+msgid "Model:"
+msgstr "Mô hình:"
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:117
+msgid "Custom Model Name:"
+msgstr "Tên mô hình tùy chỉnh:"
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:126
+msgid "Structured JSON (Reliable, includes language detection)"
+msgstr "JSON có cấu trúc (Đáng tin cậy, bao gồm phát hiện ngôn ngữ)"
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:127
+msgid "Simple Text (Fastest, no language detection)"
+msgstr "Văn bản thuần túy (Nhanh nhất, không phát hiện ngôn ngữ)"
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:128
+msgid "Fluent Style (Natural, no language detection)"
+msgstr "Phong cách trôi chảy (Tự nhiên, không phát hiện ngôn ngữ)"
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:167
+msgid "OpenRouter API URL is not configured."
+msgstr "Đường dẫn OpenRouter API URL chưa được cấu hình."
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:170
+msgid "API Key for OpenRouter is not configured."
+msgstr "Khóa API cho OpenRouter chưa được cấu hình."
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:176
+msgid "Custom model name is not specified."
+msgstr "Tên mô hình tùy chỉnh chưa được chỉ định."
+
+#: addon\globalPlugins\polyglot\services\engines\openRouter.py:269
+msgid "Invalid API response structure."
+msgstr "Cấu trúc phản hồi API không hợp lệ."
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:25
+msgid "Tencent Translate"
+msgstr "Tencent Translate"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:67
+msgid "Secret ID"
+msgstr "Secret ID"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:68
+msgid "Secret Key"
+msgstr "Secret Key"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:71
+msgid "Region:"
+msgstr "Khu vực:"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:74
+msgid "North China (Beijing)"
+msgstr "Hoa Bắc (Bắc Kinh)"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:75
+msgid "South China (Guangzhou)"
+msgstr "Hoa Nam (Quảng Châu)"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:76
+msgid "East China (Shanghai)"
+msgstr "Hoa Đông (Thượng Hải)"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:77
+msgid "Hong Kong, Macao and Taiwan (Hong Kong, China)"
+msgstr "Hồng Kông, Ma Cao và Đài Loan (Hồng Kông, Trung Quốc)"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:78
+msgid "Southeast Asia-Pacific (Singapore)"
+msgstr "Đông Nam Á - Thái Bình Dương (Singapore)"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:79
+msgid "US East (Ashburn)"
+msgstr "Đông Hoa Kỳ (Ashburn)"
+
+#: addon\globalPlugins\polyglot\services\engines\tencent.py:91
+msgid "Secret ID and Secret Key must be provided."
+msgstr "Phải cung cấp Secret ID và Secret Key."
+
+#: addon\globalPlugins\polyglot\services\engines\tencentPolyglot.py:21
+msgid "Tencent Translate (Polyglot)"
+msgstr "Tencent Translate (Polyglot)"
+
+#: addon\globalPlugins\polyglot\services\engines\tencentPolyglot.py:48
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:54
+#: addon\globalPlugins\polyglot\services\engines\volcenginePolyglot.py:56
+msgid "NVDACN Username"
+msgstr "Tên người dùng NVDACN"
+
+#: addon\globalPlugins\polyglot\services\engines\tencentPolyglot.py:49
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:55
+#: addon\globalPlugins\polyglot\services\engines\volcenginePolyglot.py:57
+msgid "NVDACN Password"
+msgstr "Mật khẩu NVDACN"
+
+#: addon\globalPlugins\polyglot\services\engines\tencentPolyglot.py:58
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:68
+#: addon\globalPlugins\polyglot\services\engines\volcenginePolyglot.py:66
+msgid "NVDACN username and password must be provided in settings."
+msgstr "Tên người dùng và mật khẩu NVDACN phải được cung cấp trong cài đặt."
+
+#: addon\globalPlugins\polyglot\services\engines\tencentPolyglot.py:92
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:106
+#: addon\globalPlugins\polyglot\services\engines\volcenginePolyglot.py:100
+msgid "API response successful but did not contain a translation result."
+msgstr "Phản hồi API thành công nhưng không chứa kết quả dịch."
+
+#. Translators: Error message when authentication with the translation service fails. {error} is the detailed error description.
+#: addon\globalPlugins\polyglot\services\engines\tencentPolyglot.py:99
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:83
+#: addon\globalPlugins\polyglot\services\engines\volcenginePolyglot.py:107
+#, python-brace-format
+msgid "Authentication failed: {error}"
+msgstr "Xác thực thất bại: {error}"
+
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:20
+msgid "VIVO Translate"
+msgstr "VIVO Translate"
+
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:24
+msgid "Server error"
+msgstr "Lỗi máy chủ"
+
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:25
+msgid "Invalid request parameters"
+msgstr "Tham số yêu cầu không hợp lệ"
+
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:78
+msgid ""
+"Could not connect to the NVDACN authentication server to get a signature. "
+"Please check your network connection or try again later."
+msgstr ""
+"Không thể kết nối với máy chủ xác thực NVDACN để lấy chữ ký điện tử. Vui "
+"lòng kiểm tra kết nối mạng hoặc thử lại sau."
+
+#: addon\globalPlugins\polyglot\services\engines\vivo.py:85
+msgid "An unknown error occurred while generating authentication info."
+msgstr "Đã xảy ra lỗi không xác định khi tạo thông tin xác thực."
+
+#: addon\globalPlugins\polyglot\services\engines\volcenginePolyglot.py:21
+msgid "Volcengine (Polyglot)"
+msgstr "Volcengine (Polyglot)"
+
+#: addon\globalPlugins\polyglot\services\engines\yandex.py:29
+msgid "Yandex Translate"
+msgstr "Yandex Translate"
+
+#: addon\globalPlugins\polyglot\services\engines\_vivoAuth.py:85
+msgid "Could not connect to the authentication server."
+msgstr "Không thể kết nối đến máy chủ xác thực."
+
+#: addon\globalPlugins\polyglot\services\engines\_vivoAuth.py:92
+msgid "Invalid response from the authentication server."
+msgstr "Phản hồi từ máy chủ xác thực không hợp lệ."
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:23
+msgid "Polyglot Interactive Translation"
+msgstr "Dịch thuật tương tác Polyglot"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:40
+#: addon\globalPlugins\polyglot\views\settings.py:54
+msgid "Translation &engine:"
+msgstr "Bộ &dịch:"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:49
+#: addon\globalPlugins\polyglot\views\settings.py:198
+msgid "Current Engine Settings"
+msgstr "Cài đặt bộ dịch hiện tại"
+
+#. --- Text Areas (Vertical Layout for better expansion) ---
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:67
+msgid "Te&xt to translate:"
+msgstr "Văn &bản cần dịch:"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:76
+msgid "Translation &result:"
+msgstr "Kết &quả dịch:"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:87
+msgid "&Translate"
+msgstr "&Dịch"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:91
+msgid "C&opy result"
+msgstr "Sa&o chép kết quả"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:92
+msgid "C&lear"
+msgstr "X&óa"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:93
+msgid "&Close"
+msgstr "&Đóng"
+
+#. Translators: Label for custom model with its name.
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:168
+#, python-brace-format
+msgid "Custom: {modelName}"
+msgstr "Tùy chỉnh: {modelName}"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:184
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:198
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:244
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:245
+msgid "Not applicable"
+msgstr "Không áp dụng"
+
+#: addon\globalPlugins\polyglot\views\interactiveDialog.py:304
+msgid "Translating..."
+msgstr "Đang dịch..."
+
+#: addon\globalPlugins\polyglot\views\settings.py:64
+msgid "Common Settings"
+msgstr "Cài đặt chung"
+
+#: addon\globalPlugins\polyglot\views\settings.py:69
+msgid "Copy manual translation results to clipboard"
+msgstr "Sao chép kết quả dịch thủ công vào bộ nhớ tạm"
+
+#: addon\globalPlugins\polyglot\views\settings.py:75
+msgid ""
+"Enable smart speech filter (skips non-translatable text like roles, states, "
+"location and other formatting information)"
+msgstr ""
+"Bật bộ lọc giọng đọc thông minh (bỏ qua văn bản không cần dịch như vai trò, "
+"trạng thái, vị trí và các thông tin định dạng khác)"
+
+#: addon\globalPlugins\polyglot\views\settings.py:79
+msgid "Clear Cache"
+msgstr "Xóa bộ nhớ đệm"
+
+#: addon\globalPlugins\polyglot\views\settings.py:204
+msgid "This engine requires no additional configuration."
+msgstr "Bộ dịch này không cần cấu hình thêm."
+
+#: addon\globalPlugins\polyglot\views\settings.py:290
+#, python-brace-format
+msgid "Clear Cache (Items: {})"
+msgstr "Xóa bộ nhớ đệm (Số lượng: {})"
+
+#. Add-on description
+#. Translators: Long description to be shown for this add-on on add-on information from add-on store
+#: buildVars.py:26
+msgid "A translation add-on for NVDA with support for multiple engines."
+msgstr "Một add-on dịch thuật dành cho NVDA hỗ trợ nhiều bộ dịch khác nhau."
+
+#. Brief changelog for this version
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:31
+msgid ""
+"### 0.9.1\n"
+"\n"
+"- Require an explicit source language for ChromeAI offline translation."
+msgstr ""
+"### 0.9.1\n"
+"\n"
+"- Yêu cầu chỉ định rõ ràng ngôn ngữ nguồn đối với tính năng dịch ngoại tuyến "
+"ChromeAI."


### PR DESCRIPTION
Add Vietnamese localization and documentation for the Polyglot NVDA add-on.

Files added:
- addon/doc/vi/readme.md: Vietnamese user guide and quick start for Polyglot (features, command layer, settings, Chrome AI offline, engines overview, contribution and license info).
- addon/locale/vi/LC_MESSAGES/nvda.po: Vietnamese message catalog (translations for UI strings, language names, error messages, prompts and help text).

This commit provides full Vietnamese docs and a PO file to enable Vietnamese UI/localization support.