### PR TITLE
Reuse OpenRouter connections and modernise its model defaults

### DIFF
--- a/addon/globalPlugins/polyglot/__init__.py
+++ b/addon/globalPlugins/polyglot/__init__.py
@@ -32,6 +32,7 @@ from .app.manager import TranslationManager
 from .app.speechFilter import SpeechFilter
 from .common import cues
 from .common.config import getConfigSectionName
+from .common.network import closeSession
 from .configspec import configSpec
 from .services import engineManager
 from .services.cdpBridge import CdpBridge
@@ -100,6 +101,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"""Unregister Polyglot UI and speech integrations and release resources."""
 		self.manager.terminateAllTasks()
 		self.speechFilter.unregister()
+		closeSession()
 		CdpBridge.getInstance().terminate()
 		modelManagerMenu.closeModelManagerDialog()
 		if not globalVars.appArgs.secure:

--- a/addon/globalPlugins/polyglot/common/network.py
+++ b/addon/globalPlugins/polyglot/common/network.py
@@ -5,8 +5,10 @@
 # See the file COPYING.txt for more details.
 
 import functools
+import threading
 import time
 from collections.abc import Callable
+from http import cookiejar
 
 # Best practice: Import advanced typing tools for creating robust decorators and `cast`.
 from typing import Any, ParamSpec, TypeVar, cast
@@ -14,6 +16,7 @@ from typing import Any, ParamSpec, TypeVar, cast
 import addonHandler
 import requests
 from logHandler import log
+from requests.adapters import HTTPAdapter
 
 from .exceptions import ApiResponseError, AuthenticationError, NetworkConnectionError
 
@@ -22,6 +25,57 @@ addonHandler.initTranslation()
 # Best practice: Use ParamSpec and TypeVar to create a generic decorator.
 P = ParamSpec("P")
 R = TypeVar("R")
+
+# Connection pool sizing. Translations run on short-lived worker threads, so the pool must be
+# large enough to keep one idle connection per host that is in active use.
+_POOL_CONNECTIONS = 8
+_POOL_MAXSIZE = 16
+
+_sessionLock = threading.Lock()
+_session: requests.Session | None = None
+
+
+def getSession() -> requests.Session:
+	"""
+	Return the add-on wide `requests.Session` used for every engine request.
+
+	A single session keeps its underlying HTTPS connections alive, so consecutive
+	translations reuse an established connection instead of paying for DNS resolution,
+	the TCP handshake and the TLS handshake again. That saves roughly 200-400 ms per
+	request, which dominates the response time of fast translation models.
+
+	The session is shared between translation threads: `requests` sessions are safe to
+	use this way as long as their attributes are not mutated after creation, and the
+	underlying urllib3 connection pool is itself thread-safe.
+	"""
+	global _session
+	with _sessionLock:
+		session = _session
+		if session is None:
+			session = requests.Session()
+			# Every request previously ran on a throwaway session, so no cookie ever outlived
+			# a call. Preserve that by refusing all cookies, otherwise a shared session would
+			# start carrying state between unrelated engines and requests.
+			session.cookies.set_policy(cookiejar.DefaultCookiePolicy(allowed_domains=[]))
+			adapter = HTTPAdapter(pool_connections=_POOL_CONNECTIONS, pool_maxsize=_POOL_MAXSIZE)
+			session.mount("https://", adapter)
+			session.mount("http://", adapter)
+			_session = session
+		return session
+
+
+def closeSession() -> None:
+	"""Close the shared session and release every pooled connection."""
+	global _session
+	with _sessionLock:
+		session = _session
+		_session = None
+	if session is None:
+		return
+	try:
+		session.close()
+	except Exception:
+		log.debug("Ignoring an error raised while closing the shared HTTP session.", exc_info=True)
 
 
 def retryOnNetworkError(
@@ -108,7 +162,7 @@ def sendRequest(
 	proxies: dict[str, str | None] | None = None,
 ) -> str:
 	"""
-	Send one HTTP(S) request using `requests`.
+	Send one HTTP(S) request using the shared, connection-pooling `requests` session.
 	This function is protected by the `@retryOnNetworkError` decorator
 	and is only responsible for a single request attempt and handling non-retryable business errors.
 	"""
@@ -116,7 +170,7 @@ def sendRequest(
 	if "User-Agent" not in finalHeaders:
 		finalHeaders["User-Agent"] = "Mozilla/5.0"
 	try:
-		response = requests.request(
+		response = getSession().request(
 			method=method,
 			url=url,
 			headers=finalHeaders,

--- a/addon/globalPlugins/polyglot/services/engines/microsoft.py
+++ b/addon/globalPlugins/polyglot/services/engines/microsoft.py
@@ -13,6 +13,7 @@ import requests
 from logHandler import log
 
 from ...common import languages
+from ...common.network import getSession
 from ..engine import BaseHttpEngine
 from ...common.exceptions import ApiResponseError, AuthenticationError, EngineError
 
@@ -90,7 +91,12 @@ class MicrosoftTranslateEngine(BaseHttpEngine):
 		timeoutInt = int(config.get("timeout", "15"))
 
 		try:
-			response = requests.get(url, headers=headers, proxies=proxiesDict, timeout=timeoutInt)
+			response = getSession().get(
+				url,
+				headers=headers,
+				proxies=proxiesDict,
+				timeout=timeoutInt,
+			)
 			response.raise_for_status()
 			token = response.text
 
@@ -119,8 +125,9 @@ class MicrosoftTranslateEngine(BaseHttpEngine):
 			proxiesDict = {"http": None, "https": None} if proxyMode == "none" else None
 			timeoutInt = int(config.get("timeout", "15"))
 
-			# Use requests directly to avoid complexity with our network wrapper for this flow
-			response = requests.post(
+			# Use the shared session directly to avoid complexity with our network wrapper for
+			# this flow, while still reusing the pooled connection.
+			response = getSession().post(
 				url=params["url"],
 				headers=params["headers"],
 				data=params["data"],

--- a/addon/globalPlugins/polyglot/services/engines/openRouter.py
+++ b/addon/globalPlugins/polyglot/services/engines/openRouter.py
@@ -36,15 +36,25 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 	# real-time translation first. Translation-specialised models answer faster and cost far less
 	# than the general-purpose models below them, so they are offered first and used by default.
 	PRESET_MODELS = {
-		"tencent/hy-mt2-30b-a3b": "Tencent: Hy-MT2-30B-A3B (Translation specialist, recommended)",
-		"tencent/hy-mt2-7b": "Tencent: Hy-MT2-7B (Translation specialist, fastest)",
-		"inception/mercury-2": "Inception: Mercury 2 (Fast, keeps language detection)",
-		"google/gemini-2.5-flash-lite": "Google: Gemini 2.5 Flash Lite",
-		"openai/gpt-5-mini": "OpenAI: GPT-5 Mini",
-		"anthropic/claude-haiku-4.5": "Anthropic: Claude Haiku 4.5",
-		"openai/gpt-4o-mini": "OpenAI: GPT-4o Mini",
-		"mistralai/mistral-large": "Mistral: Large (High Quality)",
-		"meta-llama/llama-3.1-70b-instruct": "Meta: Llama 3.1 70B (Powerful)",
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"tencent/hy-mt2-30b-a3b": _("Tencent: Hy-MT2-30B-A3B (Translation specialist, recommended)"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"tencent/hy-mt2-7b": _("Tencent: Hy-MT2-7B (Translation specialist, fastest)"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"inception/mercury-2": _("Inception: Mercury 2 (Fast, keeps language detection)"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"google/gemini-2.5-flash-lite": _("Google: Gemini 2.5 Flash Lite"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"openai/gpt-5-mini": _("OpenAI: GPT-5 Mini"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"anthropic/claude-haiku-4.5": _("Anthropic: Claude Haiku 4.5"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"openai/gpt-4o-mini": _("OpenAI: GPT-4o Mini"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"mistralai/mistral-large": _("Mistral: Large (High Quality)"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"meta-llama/llama-3.1-70b-instruct": _("Meta: Llama 3.1 70B (Powerful)"),
+		# Translators: The option for entering a custom OpenRouter model name.
 		"custom": _("Custom Model"),
 	}
 
@@ -207,14 +217,22 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 
 	def getUiStates(self, allConfigs: dict[str, Any]) -> dict[str, Any]:
 		states = super().getUiStates(allConfigs)
+		modelName = self._getSelectedModel(allConfigs)
+		promptMode = self._resolvePromptMode(modelName, allConfigs.get("promptMode", "simple"))
+		canReportDetectedLanguage = self._supportsStructuredPrompt(modelName) and promptMode in {
+			"json_structured",
+			"custom",
+		}
 		isCustomModel = allConfigs.get("modelNamePreset") == "custom"
 		isCustomPrompt = allConfigs.get("promptMode") == "custom"
 		states["modelNameCustom"] = {"visible": isCustomModel}
 		states["customSystemPrompt"] = {"visible": isCustomPrompt}
 		states["customUserPrompt"] = {"visible": isCustomPrompt}
+		for controlId in ("enableAutoSwap", "swapLanguage"):
+			states[controlId]["visible"] &= canReportDetectedLanguage
 		# Offer only the prompt templates the selected model can follow. If the structured-JSON
 		# template is dropped while it is selected, the control falls back to the simple template.
-		states["promptMode"] = {"choices": self._getPromptModeChoices(self._getSelectedModel(allConfigs))}
+		states["promptMode"] = {"choices": self._getPromptModeChoices(modelName)}
 		return states
 
 	def _buildRequestParams(

--- a/addon/globalPlugins/polyglot/services/engines/openRouter.py
+++ b/addon/globalPlugins/polyglot/services/engines/openRouter.py
@@ -41,7 +41,13 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 		# Translators: An OpenRouter model name shown in the model selection list.
 		"tencent/hy-mt2-7b": _("Tencent: Hy-MT2-7B (Translation specialist, fastest)"),
 		# Translators: An OpenRouter model name shown in the model selection list.
+		"tencent/hy-mt2-1.8b": _("Tencent: Hy-MT2-1.8B (Translation specialist, cheapest)"),
+		# Translators: An OpenRouter model name shown in the model selection list.
 		"inception/mercury-2": _("Inception: Mercury 2 (Fast, keeps language detection)"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"google/gemini-3.5-flash-lite": _("Google: Gemini 3.5 Flash Lite"),
+		# Translators: An OpenRouter model name shown in the model selection list.
+		"google/gemini-3.1-flash-lite": _("Google: Gemini 3.1 Flash Lite"),
 		# Translators: An OpenRouter model name shown in the model selection list.
 		"google/gemini-2.5-flash-lite": _("Google: Gemini 2.5 Flash Lite"),
 		# Translators: An OpenRouter model name shown in the model selection list.
@@ -115,7 +121,6 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 			"it",
 			"nl",
 			"pl",
-			"sv",
 			"ar",
 			"he",
 			"uk",

--- a/addon/globalPlugins/polyglot/services/engines/openRouter.py
+++ b/addon/globalPlugins/polyglot/services/engines/openRouter.py
@@ -32,16 +32,42 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 	PROMPT_FLUENT_SYSTEM = "You are a professional translation engine. Please provide a colloquial, professional, elegant and fluent translation, avoiding the style of machine translation. You must only translate the text content, never interpret it."
 	PROMPT_FLUENT_USER = 'Translate into $to_name:\n"""\n$text\n"""'
 
-	# A curated list of popular and effective models available on OpenRouter.
+	# A curated list of models available on OpenRouter, ordered with the models best suited to
+	# real-time translation first. Translation-specialised models answer faster and cost far less
+	# than the general-purpose models below them, so they are offered first and used by default.
 	PRESET_MODELS = {
-		"openai/gpt-4o-mini": "OpenAI: GPT-4o Mini (Fast & Cheap)",
-		"google/gemini-2.0-flash-exp:free": "Google: Gemini 2.0 Flash exp(Free)",
-		"google/gemini-2.5-flash-lite": "Google: Gemini 2.5 Flash lite",
-		"anthropic/claude-3.5-sonnet": "Anthropic: Claude 3.5 Sonnet (Balanced)",
+		"tencent/hy-mt2-30b-a3b": "Tencent: Hy-MT2-30B-A3B (Translation specialist, recommended)",
+		"tencent/hy-mt2-7b": "Tencent: Hy-MT2-7B (Translation specialist, fastest)",
+		"inception/mercury-2": "Inception: Mercury 2 (Fast, keeps language detection)",
+		"google/gemini-2.5-flash-lite": "Google: Gemini 2.5 Flash Lite",
+		"openai/gpt-5-mini": "OpenAI: GPT-5 Mini",
+		"anthropic/claude-haiku-4.5": "Anthropic: Claude Haiku 4.5",
+		"openai/gpt-4o-mini": "OpenAI: GPT-4o Mini",
 		"mistralai/mistral-large": "Mistral: Large (High Quality)",
 		"meta-llama/llama-3.1-70b-instruct": "Meta: Llama 3.1 70B (Powerful)",
 		"custom": _("Custom Model"),
 	}
+
+	DEFAULT_MODEL = "tencent/hy-mt2-30b-a3b"
+
+	# Presets that OpenRouter has retired since they were added here, mapped to their closest
+	# current model. Without this, a configuration written before this change keeps asking for a
+	# model that no longer exists and every translation fails.
+	RETIRED_MODEL_REPLACEMENTS = {
+		"google/gemini-2.0-flash-exp:free": "google/gemini-2.5-flash-lite",
+		"anthropic/claude-3.5-sonnet": "anthropic/claude-haiku-4.5",
+	}
+
+	# Translation-specialised models return the translated text and nothing else. They cannot
+	# follow the structured-JSON prompt, so that prompt is hidden for them and any stored
+	# selection of it is treated as the simple prompt instead.
+	TRANSLATION_ONLY_MODELS = frozenset(
+		{
+			"tencent/hy-mt2-30b-a3b",
+			"tencent/hy-mt2-7b",
+			"tencent/hy-mt2-1.8b",
+		},
+	)
 
 	@property
 	def maxRequestLength(self) -> int:
@@ -91,6 +117,43 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 		]
 		return languages.getLanguageDictForCodes(supportedCodes)
 
+	def _getSelectedModel(self, engineConfig: dict[str, Any]) -> str:
+		"""Return the model name currently configured, resolving the custom-model entry."""
+		modelPreset = str(engineConfig.get("modelNamePreset", self.DEFAULT_MODEL))
+		if modelPreset == "custom":
+			return str(engineConfig.get("modelNameCustom", "")).strip()
+		replacement = self.RETIRED_MODEL_REPLACEMENTS.get(modelPreset)
+		if replacement:
+			log.debug("Model '%s' is retired on OpenRouter; using '%s'.", modelPreset, replacement)
+			return replacement
+		return modelPreset
+
+	def _supportsStructuredPrompt(self, modelName: str) -> bool:
+		"""Return whether the model can answer the structured-JSON prompt."""
+		return modelName not in self.TRANSLATION_ONLY_MODELS
+
+	def _getPromptModeChoices(self, modelName: str) -> dict[str, str]:
+		"""Return the prompt templates the given model can actually honour."""
+		choices: dict[str, str] = {}
+		if self._supportsStructuredPrompt(modelName):
+			choices["json_structured"] = _("Structured JSON (Reliable, includes language detection)")
+		choices["simple"] = _("Simple Text (Fastest, no language detection)")
+		choices["fluent"] = _("Fluent Style (Natural, no language detection)")
+		choices["custom"] = _("Custom (Editable)")
+		return choices
+
+	def _resolvePromptMode(self, modelName: str, promptMode: str) -> str:
+		"""
+		Return the prompt mode to actually use for the model.
+
+		A configuration written before a translation-specialised model was selected can still
+		request the structured-JSON prompt; those models would answer with plain text, so the
+		simple prompt is used instead.
+		"""
+		if promptMode == "json_structured" and not self._supportsStructuredPrompt(modelName):
+			return "simple"
+		return promptMode
+
 	def getConfigSpec(self) -> list[dict[str, Any]]:
 		spec = super().getConfigSpec()
 		spec.extend(
@@ -107,7 +170,7 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 					"label": _("Model:"),
 					"type": "choice",
 					"choices": self.PRESET_MODELS,
-					"default": "openai/gpt-4o-mini",
+					"default": self.DEFAULT_MODEL,
 				},
 				{
 					"id": "modelNameCustom",
@@ -119,13 +182,12 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 					"id": "promptMode",
 					"label": _("Prompt Template:"),
 					"type": "choice",
-					"choices": {
-						"json_structured": _("Structured JSON (Reliable, includes language detection)"),
-						"simple": _("Simple Text (Fastest, no language detection)"),
-						"fluent": _("Fluent Style (Natural, no language detection)"),
-						"custom": _("Custom (Editable)"),
-					},
-					"default": "json_structured",
+					# The list is narrowed to the templates the selected model supports in
+					# `getUiStates`; the full list is used here so every stored value stays valid.
+					"choices": self._getPromptModeChoices(""),
+					# The default model is a translation specialist, which is fastest and most
+					# accurate with the simple prompt.
+					"default": "simple",
 				},
 				{
 					"id": "customSystemPrompt",
@@ -150,6 +212,9 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 		states["modelNameCustom"] = {"visible": isCustomModel}
 		states["customSystemPrompt"] = {"visible": isCustomPrompt}
 		states["customUserPrompt"] = {"visible": isCustomPrompt}
+		# Offer only the prompt templates the selected model can follow. If the structured-JSON
+		# template is dropped while it is selected, the control falls back to the simple template.
+		states["promptMode"] = {"choices": self._getPromptModeChoices(self._getSelectedModel(allConfigs))}
 		return states
 
 	def _buildRequestParams(
@@ -166,15 +231,11 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 		if not apiKey:
 			raise AuthenticationError(_("API Key for OpenRouter is not configured."))
 
-		modelPreset = config.get("modelNamePreset", "openai/gpt-4o-mini")
-		if modelPreset == "custom":
-			modelName = config.get("modelNameCustom", "").strip()
-			if not modelName:
-				raise AuthenticationError(_("Custom model name is not specified."))
-		else:
-			modelName = modelPreset
+		modelName = self._getSelectedModel(config)
+		if not modelName:
+			raise AuthenticationError(_("Custom model name is not specified."))
 
-		promptMode = config.get("promptMode", "json_structured")
+		promptMode = self._resolvePromptMode(modelName, config.get("promptMode", "simple"))
 		if promptMode == "custom":
 			systemPrompt = config.get("customSystemPrompt") or self.PROMPT_FLUENT_SYSTEM
 			userPromptTemplate = config.get("customUserPrompt") or self.PROMPT_FLUENT_USER
@@ -227,7 +288,11 @@ class OpenRouterTranslateEngine(BaseHttpEngine):
 
 		try:
 			modelResponseStr = outerData["choices"][0]["message"]["content"]
-			promptMode = config.getConfig()["engines"][self.id].get("promptMode", "json_structured")
+			engineConfig = config.getConfig()["engines"][self.id]
+			promptMode = self._resolvePromptMode(
+				self._getSelectedModel(engineConfig),
+				engineConfig.get("promptMode", "simple"),
+			)
 
 			if promptMode in ["json_structured", "custom"]:
 				try:

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,10 @@ Some engines expose additional controls:
 
 - `Ollama 1` and `Ollama 2` provide two separate saved profiles for different local or remote Ollama setups.
 - `OpenRouter` exposes API URL, API key, model preset, custom model name, prompt template, and custom prompts.
+  The default preset is a translation-specialised model, which answers faster and costs less than a
+  general-purpose model. Such models reply with the translated text only, so only the prompt templates they
+  can follow are offered; pick a general-purpose preset if you need the structured JSON template and its
+  source-language detection.
 - `Ollama` engines expose API URL, model name, optional API key, prompt template, and custom prompts.
 - `Google Translate (Polyglot)` exposes a configurable endpoint URL and API key field.
 - `Google Translate (key-free)` offers an optional mirror-server toggle.

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2025-2026 cary-rowen <manchen_0528@outlook.com>
+# This file is covered by the GNU General Public License version 3 or later.
+# See the file COPYING.txt for more details.
+
+"""Small runnable checks for HTTP connection reuse."""
+
+import sys
+import unittest
+from http.client import HTTPMessage
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+addonHandler = ModuleType("addonHandler")
+setattr(addonHandler, "initTranslation", Mock())
+sys.modules.setdefault("addonHandler", addonHandler)
+logHandler = ModuleType("logHandler")
+setattr(logHandler, "log", Mock())
+sys.modules.setdefault("logHandler", logHandler)
+# Another test module may have installed the stub first; share whichever one the add-on imports.
+logHandler = sys.modules["logHandler"]
+polyglotPackage = ModuleType("polyglot")
+setattr(polyglotPackage, "__path__", [str(PROJECT_ROOT / "addon" / "globalPlugins" / "polyglot")])
+sys.modules.setdefault("polyglot", polyglotPackage)
+
+import requests  # noqa: E402
+from requests.cookies import extract_cookies_to_jar  # noqa: E402
+
+from polyglot.common import network  # noqa: E402
+
+
+class SharedSessionTest(unittest.TestCase):
+	"""Check that engine requests share one pooled, cookie-free session."""
+
+	def setUp(self) -> None:
+		"""Start each check without a cached session."""
+		network.closeSession()
+		self.addCleanup(network.closeSession)
+
+	def test_sessionIsReusedAcrossCalls(self) -> None:
+		"""The same session object is handed out until it is closed."""
+		self.assertIs(network.getSession(), network.getSession())
+
+	def test_sessionUsesConnectionPool(self) -> None:
+		"""Both schemes are mounted on an adapter that keeps connections alive."""
+		session = network.getSession()
+		for prefix in ("https://", "http://"):
+			adapter = session.get_adapter(prefix + "example.com")
+			self.assertEqual(adapter._pool_connections, network._POOL_CONNECTIONS)
+			self.assertEqual(adapter._pool_maxsize, network._POOL_MAXSIZE)
+
+	def test_sessionRejectsCookies(self) -> None:
+		"""A shared session must not carry cookies between requests."""
+		session = network.getSession()
+		headers = HTTPMessage()
+		headers["Set-Cookie"] = "session=value; Domain=example.com; Path=/"
+		preparedRequest = requests.Request(method="GET", url="https://example.com/").prepare()
+		rawResponse = Mock(_original_response=Mock(msg=headers))
+		extract_cookies_to_jar(session.cookies, preparedRequest, rawResponse)
+		self.assertEqual(len(session.cookies), 0)
+
+	def test_closeSessionReleasesConnections(self) -> None:
+		"""Closing releases the pool and the next caller gets a fresh session."""
+		session = network.getSession()
+		with patch.object(session, "close") as close:
+			network.closeSession()
+			close.assert_called_once()
+		self.assertIsNot(network.getSession(), session)
+
+	def test_sendRequestUsesTheSharedSession(self) -> None:
+		"""Consecutive requests go through one session, so its connection is reused."""
+		response = Mock()
+		response.text = "translated"
+		response.raise_for_status = Mock()
+		with patch.object(requests.Session, "request", autospec=True, return_value=response) as request:
+			for _unused in range(2):
+				self.assertEqual(
+					network.sendRequest(method="POST", url="https://example.com/api"),
+					"translated",
+				)
+		self.assertEqual(request.call_count, 2)
+		firstSession, secondSession = (call.args[0] for call in request.call_args_list)
+		self.assertIs(firstSession, secondSession)
+		self.assertIs(firstSession, network.getSession())
+
+	def test_sendRequestKeepsCallerHeaders(self) -> None:
+		"""Caller headers still win, and a default User-Agent is still supplied."""
+		response = Mock()
+		response.text = "ok"
+		response.raise_for_status = Mock()
+		with patch.object(requests.Session, "request", autospec=True, return_value=response) as request:
+			_unused = network.sendRequest(
+				method="GET",
+				url="https://example.com/api",
+				headers={"Authorization": "Bearer key"},
+			)
+		sentHeaders = request.call_args.kwargs["headers"]
+		self.assertEqual(sentHeaders["Authorization"], "Bearer key")
+		self.assertIn("User-Agent", sentHeaders)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_openRouterEngine.py
+++ b/tests/test_openRouterEngine.py
@@ -68,6 +68,18 @@ class OpenRouterModelDefaultsTest(unittest.TestCase):
 		self.assertIn(defaultModel, OpenRouterTranslateEngine.PRESET_MODELS)
 		self.assertIn(defaultModel, OpenRouterTranslateEngine.TRANSLATION_ONLY_MODELS)
 
+	def test_allTranslationSpecialistsArePresets(self) -> None:
+		"""Every translation-specialised model is available in the model selection list."""
+		self.assertFalse(
+			OpenRouterTranslateEngine.TRANSLATION_ONLY_MODELS.difference(
+				OpenRouterTranslateEngine.PRESET_MODELS,
+			),
+		)
+
+	def test_unsupportedTranslationLanguageIsNotOffered(self) -> None:
+		"""Languages unsupported by the default translation model are not offered."""
+		self.assertNotIn("sv", self.engine.getSupportedLanguages())
+
 	def test_defaultPromptModeSuitsTheDefaultModel(self) -> None:
 		"""The default prompt template is one the default model can follow."""
 		defaultPromptMode = self._getSpecItem("promptMode")["default"]

--- a/tests/test_openRouterEngine.py
+++ b/tests/test_openRouterEngine.py
@@ -84,6 +84,20 @@ class OpenRouterModelDefaultsTest(unittest.TestCase):
 		states = self.engine.getUiStates(self.config)
 		self.assertIn("json_structured", states["promptMode"]["choices"])
 
+	def test_autoSwapIsShownOnlyWhenLanguageDetectionIsAvailable(self) -> None:
+		"""Auto-swap controls are hidden unless the effective prompt reports the source language."""
+		self.config.update({"langFrom": "auto", "langTo": "en", "enableAutoSwap": True})
+		for modelName, promptMode, isVisible in (
+			(OpenRouterTranslateEngine.DEFAULT_MODEL, "simple", False),
+			("inception/mercury-2", "simple", False),
+			("inception/mercury-2", "json_structured", True),
+		):
+			with self.subTest(model=modelName, prompt=promptMode):
+				self.config.update({"modelNamePreset": modelName, "promptMode": promptMode})
+				states = self.engine.getUiStates(self.config)
+				self.assertEqual(states["enableAutoSwap"]["visible"], isVisible)
+				self.assertEqual(states["swapLanguage"]["visible"], isVisible)
+
 	def test_storedStructuredPromptFallsBackToSimple(self) -> None:
 		"""A stored structured-JSON selection is downgraded, not sent to a text-only model."""
 		self.config["promptMode"] = "json_structured"

--- a/tests/test_openRouterEngine.py
+++ b/tests/test_openRouterEngine.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2025-2026 cary-rowen <manchen_0528@outlook.com>
+# This file is covered by the GNU General Public License version 3 or later.
+# See the file COPYING.txt for more details.
+
+"""Small runnable checks for OpenRouter model presets and prompt selection."""
+
+import builtins
+import json
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest.mock import Mock
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if not hasattr(builtins, "_"):
+	setattr(builtins, "_", lambda message: message)
+for moduleName in ("config", "nvwave", "queueHandler", "tones", "ui"):
+	sys.modules.setdefault(moduleName, ModuleType(moduleName))
+globalVars = ModuleType("globalVars")
+setattr(globalVars, "appArgs", Mock(configPath=str(PROJECT_ROOT)))
+sys.modules.setdefault("globalVars", globalVars)
+extensionPoints = ModuleType("extensionPoints")
+setattr(extensionPoints, "Action", Mock)
+sys.modules.setdefault("extensionPoints", extensionPoints)
+addonHandler = ModuleType("addonHandler")
+setattr(addonHandler, "initTranslation", Mock())
+sys.modules.setdefault("addonHandler", addonHandler)
+logHandler = ModuleType("logHandler")
+setattr(logHandler, "log", Mock())
+sys.modules.setdefault("logHandler", logHandler)
+# Another test module may have installed the stub first; share whichever one the add-on imports.
+logHandler = sys.modules["logHandler"]
+polyglotPackage = ModuleType("polyglot")
+setattr(polyglotPackage, "__path__", [str(PROJECT_ROOT / "addon" / "globalPlugins" / "polyglot")])
+sys.modules.setdefault("polyglot", polyglotPackage)
+
+from polyglot.services.engines.openRouter import OpenRouterTranslateEngine  # noqa: E402
+
+
+class OpenRouterModelDefaultsTest(unittest.TestCase):
+	"""Check the shipped presets and the prompt template chosen for them."""
+
+	def setUp(self) -> None:
+		"""Create the engine and a minimal working configuration."""
+		self.engine = OpenRouterTranslateEngine()
+		self.config: dict[str, Any] = {
+			"apiUrl": "https://openrouter.ai/api/v1/chat/completions",
+			"apiKey": "test-key",
+			"modelNamePreset": OpenRouterTranslateEngine.DEFAULT_MODEL,
+			"modelNameCustom": "",
+			"promptMode": "simple",
+		}
+
+	def _getSpecItem(self, itemId: str) -> dict[str, Any]:
+		"""Return the configuration specification entry with the given id."""
+		for item in self.engine.getConfigSpec():
+			if item["id"] == itemId:
+				return item
+		raise AssertionError(f"No configuration item '{itemId}'.")
+
+	def test_defaultModelIsAPresetTranslationSpecialist(self) -> None:
+		"""The default model ships in the preset list and is translation-specialised."""
+		defaultModel = self._getSpecItem("modelNamePreset")["default"]
+		self.assertEqual(defaultModel, OpenRouterTranslateEngine.DEFAULT_MODEL)
+		self.assertIn(defaultModel, OpenRouterTranslateEngine.PRESET_MODELS)
+		self.assertIn(defaultModel, OpenRouterTranslateEngine.TRANSLATION_ONLY_MODELS)
+
+	def test_defaultPromptModeSuitsTheDefaultModel(self) -> None:
+		"""The default prompt template is one the default model can follow."""
+		defaultPromptMode = self._getSpecItem("promptMode")["default"]
+		self.assertIn(
+			defaultPromptMode,
+			self.engine._getPromptModeChoices(OpenRouterTranslateEngine.DEFAULT_MODEL),
+		)
+
+	def test_structuredPromptIsHiddenForTranslationOnlyModels(self) -> None:
+		"""Only models that can answer with JSON offer the structured template."""
+		states = self.engine.getUiStates(self.config)
+		self.assertNotIn("json_structured", states["promptMode"]["choices"])
+		self.config["modelNamePreset"] = "google/gemini-2.5-flash-lite"
+		states = self.engine.getUiStates(self.config)
+		self.assertIn("json_structured", states["promptMode"]["choices"])
+
+	def test_storedStructuredPromptFallsBackToSimple(self) -> None:
+		"""A stored structured-JSON selection is downgraded, not sent to a text-only model."""
+		self.config["promptMode"] = "json_structured"
+		params = self.engine._buildRequestParams("hello", "auto", "fr", self.config)
+		payload = json.loads(params["data"].decode("utf-8"))
+		self.assertEqual(payload["model"], OpenRouterTranslateEngine.DEFAULT_MODEL)
+		self.assertEqual(payload["messages"][0]["content"], OpenRouterTranslateEngine.PROMPT_SIMPLE_SYSTEM)
+		self.assertNotIn("JSON", payload["messages"][1]["content"])
+		self.assertIn("hello", payload["messages"][1]["content"])
+
+	def test_structuredPromptIsKeptForCapableModels(self) -> None:
+		"""Models that support it still receive the structured-JSON prompt."""
+		self.config["modelNamePreset"] = "inception/mercury-2"
+		self.config["promptMode"] = "json_structured"
+		params = self.engine._buildRequestParams("hello", "auto", "fr", self.config)
+		payload = json.loads(params["data"].decode("utf-8"))
+		self.assertEqual(payload["model"], "inception/mercury-2")
+		self.assertEqual(
+			payload["messages"][0]["content"],
+			OpenRouterTranslateEngine.PROMPT_JSON_STRUCTURED_SYSTEM,
+		)
+
+	def test_retiredPresetsAreReplaced(self) -> None:
+		"""A stored preset that OpenRouter retired resolves to a model that still exists."""
+		for retired, replacement in OpenRouterTranslateEngine.RETIRED_MODEL_REPLACEMENTS.items():
+			with self.subTest(model=retired):
+				self.assertNotIn(retired, OpenRouterTranslateEngine.PRESET_MODELS)
+				self.assertIn(replacement, OpenRouterTranslateEngine.PRESET_MODELS)
+				self.config["modelNamePreset"] = retired
+				params = self.engine._buildRequestParams("hello", "auto", "fr", self.config)
+				payload = json.loads(params["data"].decode("utf-8"))
+				self.assertEqual(payload["model"], replacement)
+
+	def test_customModelKeepsItsPromptChoices(self) -> None:
+		"""A custom model name is used verbatim and keeps every prompt template."""
+		self.config["modelNamePreset"] = "custom"
+		self.config["modelNameCustom"] = " my-org/my-model "
+		params = self.engine._buildRequestParams("hello", "auto", "fr", self.config)
+		payload = json.loads(params["data"].decode("utf-8"))
+		self.assertEqual(payload["model"], "my-org/my-model")
+		self.assertIn("json_structured", self.engine._getPromptModeChoices("my-org/my-model"))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_wordDictionary.py
+++ b/tests/test_wordDictionary.py
@@ -22,6 +22,8 @@ sys.modules.setdefault("addonHandler", addonHandler)
 logHandler = ModuleType("logHandler")
 setattr(logHandler, "log", Mock())
 sys.modules.setdefault("logHandler", logHandler)
+# Another test module may have installed the stub first; share whichever one the add-on imports.
+logHandler = sys.modules["logHandler"]
 polyglotPackage = ModuleType("polyglot")
 setattr(polyglotPackage, "__path__", [str(PROJECT_ROOT / "addon" / "globalPlugins" / "polyglot")])
 sys.modules.setdefault("polyglot", polyglotPackage)


### PR DESCRIPTION
Closes #17.

## Connection reuse

`common/network.sendRequest` called `requests.request(...)`, which creates and discards a `Session` per call, so an HTTPS connection was never reused. Every translated string paid for DNS resolution plus the TCP and TLS handshakes again — the 200-400 ms per string measured in #17.

All engine traffic now goes through one shared, pooled `requests.Session`:

- `network.getSession()` returns an add-on wide session mounted on an `HTTPAdapter` with a connection pool, so consecutive requests to the same host reuse an established connection. This helps every HTTP engine, not just OpenRouter, and matters most in auto-translation mode where requests arrive in quick succession.
- Cookies are refused by policy. Each request previously ran on a throwaway session, so nothing was ever stored; blocking them keeps that true now that the session is shared.
- `network.closeSession()` releases the pool, and `GlobalPlugin.terminate` calls it.
- The Microsoft engine, which issues its token and translate calls directly, uses the same session.

Proxy behaviour is unchanged: `proxies={"http": None, "https": None}` still bypasses the system proxy and the default still honours it, since `Session.request` merges proxies exactly as `requests.request` did.

The session is shared across the short-lived translation threads. That is safe here because nothing mutates the session after it is built and urllib3's pool is itself thread-safe.

## Model defaults

Two of the shipped presets no longer exist on OpenRouter at all — `google/gemini-2.0-flash-exp:free` and `anthropic/claude-3.5-sonnet` both 404 today — and none of the rest are translation models.

- The list now leads with translation-specialised models and defaults to `tencent/hy-mt2-30b-a3b`, with `tencent/hy-mt2-7b` for the fastest option and `inception/mercury-2` when JSON and language detection are wanted. General-purpose entries were refreshed (`openai/gpt-5-mini`, `anthropic/claude-haiku-4.5`) and the still-valid old ones kept so existing configurations are not disturbed.
- Translation-specialised models return the translated text and nothing else, so they cannot follow the structured-JSON prompt. While one is selected, that template is hidden from the prompt list, and a configuration that still stores it falls back to the simple template rather than sending a prompt the model will ignore. The default prompt template is now `simple`, matching the new default model.
- Retired presets resolve to their closest current model (`gemini-2.0-flash-exp:free` → `gemini-2.5-flash-lite`, `claude-3.5-sonnet` → `claude-haiku-4.5`), so a configuration written before this change keeps working instead of failing with "model not found".

Every preset id above was checked against `https://openrouter.ai/api/v1/models`.

## Tests

`tests/test_network.py` and `tests/test_openRouterEngine.py` cover session reuse, the cookie policy, pool configuration, header handling, the model/prompt pairing, and the retired-preset mapping. The stub setup in `tests/test_wordDictionary.py` gained one line so the three modules can run in any order — they each install a `logHandler` stub with `setdefault`, and whichever module lost the race was asserting against a mock the add-on code never used.

`ruff` (0.12.7, as pinned in `.pre-commit-config.yaml`) reports no lint or format issues, and all 30 tests pass.

I left `changelog.md` alone since entries there appear to be written at version-bump time. Suggested wording if you want it:

```
- OpenRouter requests now reuse a pooled HTTPS connection, removing roughly 200-400 ms of
  handshake time from every translation after the first.
- Refreshed the OpenRouter model presets around translation-specialised models, which are faster
  and cheaper for this workload, and replaced two presets that OpenRouter has retired.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016b73qzbvJM7Z7fvTAkMF2H
