### PR TITLE
feat: store engine credentials outside NVDA's configuration file

### DIFF
--- a/addon/globalPlugins/polyglot/__init__.py
+++ b/addon/globalPlugins/polyglot/__init__.py
@@ -31,6 +31,7 @@ from scriptHandler import script
 from .app.manager import TranslationManager
 from .app.speechFilter import SpeechFilter
 from .common import cues
+from .common import secretStore
 from .common.config import getConfigSectionName
 from .common.network import closeSession
 from .configspec import configSpec
@@ -68,12 +69,68 @@ def _buildFinalConfigSpec() -> dict[str, ConfigObj]:
 		for item in engineSpecList:
 			try:
 				handler = uiFactory.getControlHandler(item["type"])
+				if handler.isSecret:
+					# Credentials live in the secret store, never in NVDA's configuration file.
+					continue
 				defaultVal = handler.formatConfigDefault(item["default"])
 				specStr = f"{item['id']} = {handler.configType}(default={defaultVal})"
 				engineSection.merge(ConfigObj([specStr], list_values=False))
 			except ValueError:
 				log.warning(f"Engine '{engineId}' has an unknown control type '{item['type']}'. Skipping.")
 	return {getConfigSectionName(): finalSpec}
+
+
+def _migratePlainTextCredentials() -> None:
+	"""Move credentials saved by earlier releases out of NVDA's configuration file.
+
+	Polyglot 1.2.0 and earlier kept API keys as plain text in ``nvda.ini``, where they were copied into
+	portable copies and debug logs, stayed readable by other add-ons, and survived uninstalling the
+	add-on. Each value found there is handed to the secret store and then removed, whether or not it
+	could be stored, so that no plain-text copy is left behind.
+	"""
+	removedCount = 0
+	migratedCount = 0
+	baseProfile = config.conf.profiles[0]
+	# NVDA offers no public way to flag a named profile as needing to be written back to disk.
+	dirtyProfiles: set[str] | None = getattr(config.conf, "_dirtyProfiles", None)
+	for profile in config.conf.profiles:
+		enginesSection = profile.get(getConfigSectionName(), {}).get("engines")
+		if not enginesSection:
+			continue
+		profileRemovedCount = 0
+		for engine in engineManager.getAllEngines():
+			engineSection = enginesSection.get(engine.id)
+			if not engineSection:
+				continue
+			for key, defaultValue in engineManager.getSecretDefaults(engine).items():
+				if key not in engineSection:
+					continue
+				value = str(engineSection.pop(key) or "").strip()
+				profileRemovedCount += 1
+				if not value or value == defaultValue:
+					# Nothing worth keeping: the entry was blank or held the built-in default.
+					continue
+				migratedCount += 1
+				if secretStore.getSecret(engine.id, key):
+					# The environment or an earlier migration already supplies this credential.
+					continue
+				if not secretStore.setSecret(engine.id, key, value):
+					log.error(
+						f"""The '{engine.id}' credential '{key}' could not be moved to secure storage and has been removed from the NVDA configuration file. Enter it again in Polyglot's settings.""",
+					)
+		removedCount += profileRemovedCount
+		if profileRemovedCount and profile is not baseProfile and dirtyProfiles is not None:
+			dirtyProfiles.add(profile.name)
+	if not removedCount:
+		return
+	if migratedCount:
+		log.info(f"Moved {migratedCount} credential(s) out of the NVDA configuration file.")
+	else:
+		log.debug(f"Removed {removedCount} unused credential entries from the NVDA configuration file.")
+	try:
+		config.conf.save()
+	except Exception:
+		log.exception("Could not save the NVDA configuration after removing plain-text credentials.")
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
@@ -88,6 +145,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		finalSpec = _buildFinalConfigSpec()
 		# Merge this final spec into NVDA's configuration.
 		config.conf.spec.merge(finalSpec)
+		if not globalVars.appArgs.secure:
+			# A secure session must not copy the user's credentials into the system account's locker.
+			_migratePlainTextCredentials()
 		self.manager = TranslationManager()
 		self.speechFilter = SpeechFilter(self.manager)
 		self.speechFilter.register()

--- a/addon/globalPlugins/polyglot/app/manager.py
+++ b/addon/globalPlugins/polyglot/app/manager.py
@@ -311,9 +311,7 @@ class TranslationManager:
 					),
 				)
 			return
-		if engineId not in conf["engines"]:
-			conf["engines"][engineId] = {}
-		engineConfig = conf["engines"][engineId].dict()
+		engineConfig = engineManager.getResolvedEngineConfig(currentEngine)
 		shouldUseLocalDictionary = (
 			isManual and shouldPreferLocalDictionary and conf.get("enableLocalDictionaryForTranslation", True)
 		)
@@ -361,9 +359,7 @@ class TranslationManager:
 			conf["engine"] = fallbackEngine.id
 			engineId = fallbackEngine.id
 			currentEngine = fallbackEngine
-			if engineId not in conf["engines"]:
-				conf["engines"][engineId] = {}
-			engineConfig = conf["engines"][engineId].dict()
+			engineConfig = engineManager.getResolvedEngineConfig(currentEngine)
 			langFrom = None
 			langTo = None
 		try:

--- a/addon/globalPlugins/polyglot/common/secretStore.py
+++ b/addon/globalPlugins/polyglot/common/secretStore.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2025-2026 cary-rowen <cary-rowen@outlook.com>
+# This file is covered by the GNU General Public License version 3 or later.
+# See the file COPYING.txt for more details.
+
+"""Storage for engine credentials outside NVDA's configuration file.
+
+API keys, tokens, and passwords are never written to ``nvda.ini``. A credential is taken from an
+environment variable when one is set, and is otherwise kept in the Windows Credential Locker, where
+Windows encrypts it for the signed-in account. Keeping credentials out of ``nvda.ini`` keeps them out
+of NVDA's log and out of portable copies, denies them to other add-ons, and lets users review or
+remove them from Windows' own Credential Manager.
+"""
+
+import ctypes
+import os
+import re
+from ctypes import wintypes
+
+from logHandler import log
+
+#: Control type used by engines for configuration items that hold a credential.
+SECRET_CONTROL_TYPE = "password"
+
+#: Prefix shared by every credential Polyglot writes to the Windows Credential Locker.
+TARGET_PREFIX = "NVDA/Polyglot/"
+
+#: Prefix shared by every environment variable that can supply a credential.
+ENVIRONMENT_PREFIX = "POLYGLOT_"
+
+#: Description stored with each credential so it is recognisable in Windows' Credential Manager.
+_CREDENTIAL_COMMENT = "Credential for the Polyglot NVDA add-on."
+
+_CRED_TYPE_GENERIC = 1
+# Credentials stay on this machine and are never roamed to another one.
+_CRED_PERSIST_LOCAL_MACHINE = 2
+#: Maximum credential blob size in bytes, as documented for ``CREDENTIALW``.
+_CRED_MAX_CREDENTIAL_BLOB_SIZE = 5 * 512
+_ERROR_NOT_FOUND = 1168
+
+
+class _Credential(ctypes.Structure):
+	"""Mirror the Windows ``CREDENTIALW`` structure."""
+
+	_fields_ = (
+		("Flags", wintypes.DWORD),
+		("Type", wintypes.DWORD),
+		("TargetName", wintypes.LPWSTR),
+		("Comment", wintypes.LPWSTR),
+		("LastWritten", wintypes.FILETIME),
+		("CredentialBlobSize", wintypes.DWORD),
+		("CredentialBlob", ctypes.POINTER(ctypes.c_byte)),
+		("Persist", wintypes.DWORD),
+		("AttributeCount", wintypes.DWORD),
+		("Attributes", ctypes.c_void_p),
+		("TargetAlias", wintypes.LPWSTR),
+		("UserName", wintypes.LPWSTR),
+	)
+
+
+def _loadCredentialApi() -> "ctypes.WinDLL | None":
+	"""Return the Windows credential management library, or None when it cannot be used."""
+	try:
+		library = ctypes.WinDLL("advapi32", use_last_error=True)
+	except (AttributeError, OSError):
+		log.error("The Windows Credential Locker is unavailable; Polyglot cannot store credentials.")
+		return None
+	credentialPointer = ctypes.POINTER(_Credential)
+	library.CredReadW.argtypes = (
+		wintypes.LPCWSTR,
+		wintypes.DWORD,
+		wintypes.DWORD,
+		ctypes.POINTER(credentialPointer),
+	)
+	library.CredReadW.restype = wintypes.BOOL
+	library.CredWriteW.argtypes = (credentialPointer, wintypes.DWORD)
+	library.CredWriteW.restype = wintypes.BOOL
+	library.CredDeleteW.argtypes = (wintypes.LPCWSTR, wintypes.DWORD, wintypes.DWORD)
+	library.CredDeleteW.restype = wintypes.BOOL
+	library.CredEnumerateW.argtypes = (
+		wintypes.LPCWSTR,
+		wintypes.DWORD,
+		ctypes.POINTER(wintypes.DWORD),
+		ctypes.POINTER(ctypes.POINTER(credentialPointer)),
+	)
+	library.CredEnumerateW.restype = wintypes.BOOL
+	library.CredFree.argtypes = (ctypes.c_void_p,)
+	library.CredFree.restype = None
+	return library
+
+
+_credentialApi: "ctypes.WinDLL | None" = _loadCredentialApi()
+
+
+def getTargetName(engineId: str, key: str) -> str:
+	"""Return the Credential Locker target name holding one engine credential."""
+	return f"{TARGET_PREFIX}{engineId}/{key}"
+
+
+def getEnvironmentVariableName(engineId: str, key: str) -> str:
+	"""Return the environment variable that can supply one engine credential."""
+	return ENVIRONMENT_PREFIX + re.sub(r"[^A-Z0-9]", "_", f"{engineId}_{key}".upper())
+
+
+def getFromEnvironment(engineId: str, key: str) -> str | None:
+	"""Return an engine credential supplied by the environment, or None when there is none."""
+	value = os.environ.get(getEnvironmentVariableName(engineId, key), "").strip()
+	return value or None
+
+
+def isProvidedByEnvironment(engineId: str, key: str) -> bool:
+	"""Return whether the environment supplies an engine credential, overriding any stored one."""
+	return getFromEnvironment(engineId, key) is not None
+
+
+def getSecret(engineId: str, key: str) -> str:
+	"""Return a stored engine credential, or an empty string when none is available."""
+	fromEnvironment = getFromEnvironment(engineId, key)
+	if fromEnvironment is not None:
+		return fromEnvironment
+	if _credentialApi is None:
+		return ""
+	credential = ctypes.POINTER(_Credential)()
+	if not _credentialApi.CredReadW(
+		getTargetName(engineId, key),
+		_CRED_TYPE_GENERIC,
+		0,
+		ctypes.byref(credential),
+	):
+		errorCode = ctypes.get_last_error()
+		if errorCode != _ERROR_NOT_FOUND:
+			log.error(f"Could not read the '{engineId}' credential '{key}' (Windows error {errorCode}).")
+		return ""
+	try:
+		blobSize = credential.contents.CredentialBlobSize
+		blob = ctypes.string_at(credential.contents.CredentialBlob, blobSize) if blobSize else b""
+	finally:
+		_credentialApi.CredFree(credential)
+	return blob.decode("utf-16-le", errors="replace")
+
+
+def setSecret(engineId: str, key: str, value: str) -> bool:
+	"""Store one engine credential, removing it instead when value is empty.
+
+	:return: Whether the credential was stored or removed successfully.
+	"""
+	value = value.strip()
+	if not value:
+		return deleteSecret(engineId, key)
+	if _credentialApi is None:
+		log.error(f"Could not store the '{engineId}' credential '{key}'; no secure storage is available.")
+		return False
+	blob = value.encode("utf-16-le")
+	if len(blob) > _CRED_MAX_CREDENTIAL_BLOB_SIZE:
+		log.error(f"The '{engineId}' credential '{key}' is too long for the Windows Credential Locker.")
+		return False
+	# The buffer must outlive the CredWriteW call, so it is held in its own local variable.
+	blobBuffer = ctypes.create_string_buffer(blob, len(blob))
+	credential = _Credential(
+		Flags=0,
+		Type=_CRED_TYPE_GENERIC,
+		TargetName=getTargetName(engineId, key),
+		Comment=_CREDENTIAL_COMMENT,
+		CredentialBlobSize=len(blob),
+		CredentialBlob=ctypes.cast(blobBuffer, ctypes.POINTER(ctypes.c_byte)),
+		Persist=_CRED_PERSIST_LOCAL_MACHINE,
+		AttributeCount=0,
+		Attributes=None,
+		TargetAlias=None,
+		UserName=engineId,
+	)
+	if _credentialApi.CredWriteW(ctypes.byref(credential), 0):
+		return True
+	log.error(
+		f"Could not store the '{engineId}' credential '{key}' (Windows error {ctypes.get_last_error()}).",
+	)
+	return False
+
+
+def deleteSecret(engineId: str, key: str) -> bool:
+	"""Remove one stored engine credential.
+
+	:return: Whether no stored copy of the credential remains.
+	"""
+	if _credentialApi is None:
+		# Nothing can have been stored, so there is nothing left to remove.
+		return True
+	if _credentialApi.CredDeleteW(getTargetName(engineId, key), _CRED_TYPE_GENERIC, 0):
+		return True
+	errorCode = ctypes.get_last_error()
+	if errorCode == _ERROR_NOT_FOUND:
+		return True
+	log.error(f"Could not remove the '{engineId}' credential '{key}' (Windows error {errorCode}).")
+	return False
+
+
+def getStoredTargetNames() -> list[str]:
+	"""Return the target names of every credential Polyglot has stored on this machine."""
+	if _credentialApi is None:
+		return []
+	count = wintypes.DWORD(0)
+	credentials = ctypes.POINTER(ctypes.POINTER(_Credential))()
+	if not _credentialApi.CredEnumerateW(
+		f"{TARGET_PREFIX}*",
+		0,
+		ctypes.byref(count),
+		ctypes.byref(credentials),
+	):
+		errorCode = ctypes.get_last_error()
+		if errorCode != _ERROR_NOT_FOUND:
+			log.error(f"Could not list the stored Polyglot credentials (Windows error {errorCode}).")
+		return []
+	try:
+		targetNames = (credentials[index].contents.TargetName for index in range(count.value))
+		return [targetName for targetName in targetNames if targetName]
+	finally:
+		_credentialApi.CredFree(credentials)
+
+
+def deleteAllSecrets() -> int:
+	"""Remove every credential Polyglot has stored, and return how many were removed."""
+	if _credentialApi is None:
+		return 0
+	removedCount = 0
+	for targetName in getStoredTargetNames():
+		if _credentialApi.CredDeleteW(targetName, _CRED_TYPE_GENERIC, 0):
+			removedCount += 1
+		else:
+			errorCode = ctypes.get_last_error()
+			log.error(f"Could not remove the credential '{targetName}' (Windows error {errorCode}).")
+	return removedCount

--- a/addon/globalPlugins/polyglot/services/engineManager.py
+++ b/addon/globalPlugins/polyglot/services/engineManager.py
@@ -11,10 +11,13 @@ from typing import Any
 
 from logHandler import log
 
+from ..common import secretStore
 from . import engines
 from .engine import TranslationEngine
 
 _engineInstances: list[TranslationEngine] | None = None
+#: Credential setting IDs mapped to their built-in defaults, cached per engine ID.
+_secretDefaults: dict[str, dict[str, str]] = {}
 
 
 def _scanAndLoadEngines() -> None:
@@ -59,6 +62,45 @@ def _getEngineConfig(engineId: str) -> dict[str, Any]:
 
 	conf = config.getConfig()
 	return conf["engines"].get(engineId, {})
+
+
+def getEngineConfigSpec(engine: TranslationEngine) -> list[dict[str, Any]]:
+	"""Return an engine's control specifications, each tagged with the owning engine ID.
+
+	Credential controls are stored per engine in the secret store rather than in NVDA's configuration
+	file, so they need to know which engine they belong to.
+	"""
+	spec = engine.getConfigSpec()
+	for item in spec:
+		item["engineId"] = engine.id
+	return spec
+
+
+def getSecretDefaults(engine: TranslationEngine) -> dict[str, str]:
+	"""Return an engine's credential setting IDs mapped to their built-in default values."""
+	cached = _secretDefaults.get(engine.id)
+	if cached is None:
+		cached = {
+			str(item["id"]): str(item.get("default", ""))
+			for item in engine.getConfigSpec()
+			if item.get("type") == secretStore.SECRET_CONTROL_TYPE
+		}
+		_secretDefaults[engine.id] = cached
+	return cached
+
+
+def getResolvedEngineConfig(engine: TranslationEngine) -> dict[str, Any]:
+	"""Return an engine's saved settings with its credentials taken from the secret store."""
+	from ..common import config
+
+	conf = config.getConfig()
+	if engine.id not in conf["engines"]:
+		conf["engines"][engine.id] = {}
+	engineConfig: dict[str, Any] = conf["engines"][engine.id].dict()
+	for key, defaultValue in getSecretDefaults(engine).items():
+		# A stale plain-text value must never win over the secret store or the built-in default.
+		engineConfig[key] = secretStore.getSecret(engine.id, key) or defaultValue
+	return engineConfig
 
 
 def getEnabledEngines() -> list[TranslationEngine]:

--- a/addon/globalPlugins/polyglot/views/factory.py
+++ b/addon/globalPlugins/polyglot/views/factory.py
@@ -8,8 +8,14 @@ from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any
 
+import addonHandler
 import wx
 from configobj.validate import is_boolean
+from logHandler import log
+
+from ..common import secretStore
+
+addonHandler.initTranslation()
 
 # Create a Type Alias for complex, reused types.
 ConfigSpec = dict[str, Any]
@@ -18,6 +24,11 @@ ConfigSection = dict[str, Any]
 
 class ControlHandlerBase:
 	"""Define the configuration and wx-control conversion contract."""
+
+	@property
+	def isSecret(self) -> bool:
+		"""Return whether values of this type are credentials kept out of NVDA's configuration file."""
+		return False
 
 	@property
 	def configType(self) -> str:
@@ -178,6 +189,70 @@ class TextHandler(LabeledControlHandler):
 		configSection[spec["id"]] = self.getValueFromControl(control)
 
 
+class PasswordHandler(TextHandler):
+	"""Adapt credential configuration items to wx text controls backed by the secret store.
+
+	Credentials never reach NVDA's configuration file, so specifications handled here must carry the
+	owning engine's ID in an ``engineId`` entry; see :func:`engineManager.getEngineConfigSpec`.
+	"""
+
+	@property
+	def isSecret(self) -> bool:
+		return True
+
+	def _getEngineId(self, spec: ConfigSpec) -> str:
+		"""Return the engine owning a credential, or an empty string when it is unknown."""
+		engineId = str(spec.get("engineId", ""))
+		if not engineId:
+			log.error(
+				f"""Credential setting '{spec.get("id")}' is not bound to an engine, so it cannot be stored securely.""",
+			)
+		return engineId
+
+	def createControlPair(
+		self,
+		panel: wx.Window,
+		spec: ConfigSpec,
+	) -> tuple[wx.StaticText | None, wx.Control]:
+		label, control = super().createControlPair(panel, spec)
+		engineId = self._getEngineId(spec)
+		if label is not None and engineId and secretStore.isProvidedByEnvironment(engineId, spec["id"]):
+			label.SetLabel(
+				# Translators: Label for a credential field whose value comes from an environment
+				# variable. {label} is the usual field label, {variable} is the variable name.
+				_("{label} (set by the {variable} environment variable)").format(
+					label=spec["label"],
+					variable=secretStore.getEnvironmentVariableName(engineId, spec["id"]),
+				),
+			)
+		return (label, control)
+
+	def loadFromConfig(self, control: wx.Control, configSection: ConfigSection, spec: ConfigSpec) -> None:
+		assert isinstance(control, wx.TextCtrl)
+		engineId = self._getEngineId(spec)
+		if engineId and secretStore.isProvidedByEnvironment(engineId, spec["id"]):
+			# The environment wins over anything the user could type here.
+			control.SetValue("")
+			control.Disable()
+			return
+		stored = secretStore.getSecret(engineId, spec["id"]) if engineId else ""
+		self.setValueToControl(control, stored or spec.get("default", ""), spec)
+
+	def saveToConfig(self, control: wx.Control, configSection: ConfigSection, spec: ConfigSpec) -> None:
+		assert isinstance(control, wx.TextCtrl)
+		# configSection is deliberately untouched: credentials never reach NVDA's configuration file.
+		engineId = self._getEngineId(spec)
+		if not engineId or secretStore.isProvidedByEnvironment(engineId, spec["id"]):
+			return
+		value = self.getValueFromControl(control)
+		if value.strip() == str(spec.get("default", "")).strip():
+			# The built-in default needs no stored copy.
+			_unused = secretStore.deleteSecret(engineId, spec["id"])
+			return
+		if not secretStore.setSecret(engineId, spec["id"], value):
+			log.error(f"Could not save the '{engineId}' credential '{spec['id']}' to secure storage.")
+
+
 class ChoiceHandler(LabeledControlHandler):
 	"""Adapt enumerated string configuration items to wx choices."""
 
@@ -317,7 +392,7 @@ class SpinCtrlHandler(LabeledControlHandler):
 _controlHandlers: dict[str, ControlHandlerBase] = {
 	"checkbox": CheckboxHandler(),
 	"text": TextHandler(),
-	"password": TextHandler(),
+	"password": PasswordHandler(),
 	"choice": ChoiceHandler(),
 	"spinctrl": SpinCtrlHandler(),
 }

--- a/addon/globalPlugins/polyglot/views/settings.py
+++ b/addon/globalPlugins/polyglot/views/settings.py
@@ -9,6 +9,8 @@ from collections import OrderedDict
 from typing import Any
 
 import addonHandler
+import gui
+import ui
 import wx
 from gui import guiHelper
 from gui.settingsDialogs import SettingsPanel
@@ -16,6 +18,7 @@ from logHandler import log
 
 from ..common.cache import TranslationCache
 from ..common import config
+from ..common import secretStore
 from ..services import engineManager
 from . import factory as uiFactory
 
@@ -102,6 +105,10 @@ class TranslationSettingsPanel(SettingsPanel):
 			),
 		)
 		self.clearCacheButton = commonSHelper.addItem(wx.Button(self, label=_("Clear Cache")))
+		self.clearCredentialsButton = commonSHelper.addItem(
+			# Translators: Button that deletes every API key Polyglot has stored in the Windows Credential Locker.
+			wx.Button(self, label=_("Clear Stored API Keys")),
+		)
 		_unused = sHelper.addItem(commonSizer, flag=wx.EXPAND)
 
 		self.engineChoice.Bind(wx.EVT_CHOICE, self.onEngineChanged)
@@ -110,6 +117,7 @@ class TranslationSettingsPanel(SettingsPanel):
 		self.enableLocalDictionaryForTextReviewCheckbox.Bind(wx.EVT_CHECKBOX, self.onAnyControlChanged)
 		self.enableSmartFilterCheckbox.Bind(wx.EVT_CHECKBOX, self.onAnyControlChanged)
 		self.clearCacheButton.Bind(wx.EVT_BUTTON, self.onClearCache)
+		self.clearCredentialsButton.Bind(wx.EVT_BUTTON, self.onClearCredentials)
 
 		self._populateInitialState()
 
@@ -232,7 +240,7 @@ class TranslationSettingsPanel(SettingsPanel):
 			return panel
 
 		engineConf = config.getConfig()["engines"].get(engine.id, {})
-		configSpecList = engine.getConfigSpec()
+		configSpecList = engineManager.getEngineConfigSpec(engine)
 
 		self.dynamicControls[engineId] = {}
 
@@ -309,9 +317,10 @@ class TranslationSettingsPanel(SettingsPanel):
 				self.uiModel[cid] = info["handler"].getValueFromControl(info["control"])
 
 	def onPanelActivated(self):
-		"""Refresh cache information when the panel becomes active."""
+		"""Refresh cache and stored credential information when the panel becomes active."""
 		super().onPanelActivated()
 		self._updateCacheButton()
+		self._updateCredentialsButton()
 
 	def _getSelectedEngineId(self) -> str | None:
 		selection = self.engineChoice.GetSelection()
@@ -333,3 +342,46 @@ class TranslationSettingsPanel(SettingsPanel):
 
 	def _updateCacheButton(self):
 		self.clearCacheButton.SetLabel(_("Clear Cache (Items: {})").format(self.cache.getItemCount()))
+
+	def onClearCredentials(self, event: wx.Event):
+		"""Delete every API key Polyglot has stored, after confirming with the user."""
+		storedCount = len(secretStore.getStoredTargetNames())
+		if not storedCount:
+			# Translators: Message reported when there is no stored API key to delete.
+			ui.message(_("Polyglot has no stored API keys."))
+			return
+		if (
+			gui.messageBox(
+				# Translators: Confirmation prompt shown before deleting stored API keys. {count} is how many are stored.
+				_(
+					"Delete the {count} API key(s) Polyglot has stored for this Windows account? You will have to enter them again to use the engines that need them.",
+				).format(count=storedCount),
+				# Translators: Title of the dialog confirming deletion of stored API keys.
+				_("Clear Stored API Keys"),
+				wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
+				self,
+			)
+			!= wx.YES
+		):
+			return
+		removedCount = secretStore.deleteAllSecrets()
+		self._reloadCredentialControls()
+		self._updateCredentialsButton()
+		# Translators: Message reported after stored API keys are deleted. {count} is how many were deleted.
+		ui.message(_("Deleted {count} stored API key(s).").format(count=removedCount))
+		wx.CallAfter(self.clearCredentialsButton.SetFocus)
+
+	def _reloadCredentialControls(self):
+		"""Refresh every credential field from the secret store."""
+		enginesConf = config.getConfig()["engines"]
+		for engineId, controls in self.dynamicControls.items():
+			engineConf = enginesConf.get(engineId, {})
+			for info in controls.values():
+				if info["handler"].isSecret:
+					info["handler"].loadFromConfig(info["control"], engineConf, info["spec"])
+
+	def _updateCredentialsButton(self):
+		self.clearCredentialsButton.SetLabel(
+			# Translators: Label of the button that deletes stored API keys. {} is how many are stored.
+			_("Clear Stored API Keys (Items: {})").format(len(secretStore.getStoredTargetNames())),
+		)

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,17 @@ Current dictionary size:
 - `Use the local English-Chinese dictionary in text review`: Controls local definitions for NVDA text review.
 - `Enable smart speech filter`: When translating spoken NVDA output, skips non-content speech such as roles, states, location, and formatting details where possible.
 - `Clear Cache`: Clears the persistent translation cache and shows the current item count in the button label.
+- `Clear Stored API Keys`: Deletes every API key, token, and password Polyglot has stored for your Windows account, and shows how many are stored in the button label.
+
+### API Key Storage
+
+API keys, tokens, and passwords are never written to `nvda.ini`. They are kept in the Windows Credential Locker, where Windows encrypts them for the signed-in account. This means they do not appear in NVDA's log at debug level, are not copied into portable copies of NVDA, and are not readable by other add-ons through NVDA's configuration.
+
+Each credential is stored under a target name of the form `NVDA/Polyglot/<engine>/<setting>`, for example `NVDA/Polyglot/deepl/apiKey`. You can review or delete them from Windows itself: `Control Panel -> User Accounts -> Credential Manager -> Windows Credentials`, or by pressing `Clear Stored API Keys` in Polyglot's settings.
+
+A credential can also come from an environment variable, which is useful for shared or managed machines where nothing should be stored at all. The variable name is `POLYGLOT_` followed by the engine ID and the setting name in upper case, for example `POLYGLOT_DEEPL_APIKEY`, `POLYGLOT_OPENROUTER_APIKEY`, or `POLYGLOT_TENCENT_SECRETKEY`. When such a variable is set, it takes precedence over anything stored, and the matching settings field is disabled and labelled with the variable name.
+
+Upgrading from Polyglot 1.2.0 or earlier moves any keys already saved in `nvda.ini` into the Credential Locker and removes the plain-text copies the first time the add-on starts. If secure storage is unavailable, the plain-text copy is still removed and an error is written to the log; re-enter the key in Polyglot's settings.
 
 ### Shared Engine Settings
 

--- a/tests/test_secretStore.py
+++ b/tests/test_secretStore.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2025-2026 cary-rowen <cary-rowen@outlook.com>
+# This file is covered by the GNU General Public License version 3 or later.
+# See the file COPYING.txt for more details.
+
+"""Small runnable checks for credential storage outside NVDA's configuration file."""
+
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+addonHandler = ModuleType("addonHandler")
+setattr(addonHandler, "initTranslation", Mock())
+sys.modules.setdefault("addonHandler", addonHandler)
+logHandler = ModuleType("logHandler")
+setattr(logHandler, "log", Mock())
+sys.modules.setdefault("logHandler", logHandler)
+polyglotPackage = ModuleType("polyglot")
+setattr(polyglotPackage, "__path__", [str(PROJECT_ROOT / "addon" / "globalPlugins" / "polyglot")])
+sys.modules.setdefault("polyglot", polyglotPackage)
+
+from polyglot.common import secretStore  # noqa: E402
+
+
+#: An engine ID no real engine uses, so the checks cannot disturb stored credentials.
+TEST_ENGINE_ID = "polyglotSelfTest"
+
+
+class NamingTest(unittest.TestCase):
+	"""Check how credentials are addressed in Windows and in the environment."""
+
+	def test_targetNamesAreScopedToPolyglot(self) -> None:
+		"""Every stored credential is listed under Polyglot's own prefix."""
+		targetName = secretStore.getTargetName("deepl", "apiKey")
+		self.assertTrue(targetName.startswith(secretStore.TARGET_PREFIX))
+		self.assertEqual(targetName, "NVDA/Polyglot/deepl/apiKey")
+
+	def test_environmentVariableNamesAreUpperCaseAndSafe(self) -> None:
+		"""Engine and setting names become a single upper-case variable name."""
+		self.assertEqual(
+			secretStore.getEnvironmentVariableName("openrouter", "apiKey"),
+			"POLYGLOT_OPENROUTER_APIKEY",
+		)
+		self.assertEqual(
+			secretStore.getEnvironmentVariableName("chrome_ai", "secretKey"),
+			"POLYGLOT_CHROME_AI_SECRETKEY",
+		)
+
+
+class EnvironmentOverrideTest(unittest.TestCase):
+	"""Check that the environment can supply a credential without any stored copy."""
+
+	def setUp(self) -> None:
+		self.variableName = secretStore.getEnvironmentVariableName(TEST_ENGINE_ID, "apiKey")
+
+	def test_environmentValueIsUsed(self) -> None:
+		"""A credential set in the environment is returned as-is."""
+		with patch.dict("os.environ", {self.variableName: "  from-environment  "}):
+			self.assertTrue(secretStore.isProvidedByEnvironment(TEST_ENGINE_ID, "apiKey"))
+			self.assertEqual(secretStore.getSecret(TEST_ENGINE_ID, "apiKey"), "from-environment")
+
+	def test_blankEnvironmentValueIsIgnored(self) -> None:
+		"""An empty variable does not count as an override."""
+		with patch.dict("os.environ", {self.variableName: "   "}):
+			self.assertFalse(secretStore.isProvidedByEnvironment(TEST_ENGINE_ID, "apiKey"))
+
+	def test_environmentWinsOverStoredValue(self) -> None:
+		"""The environment takes precedence over the Windows Credential Locker."""
+		with patch.object(secretStore, "_credentialApi", None):
+			with patch.dict("os.environ", {self.variableName: "from-environment"}):
+				self.assertEqual(secretStore.getSecret(TEST_ENGINE_ID, "apiKey"), "from-environment")
+
+
+@unittest.skipIf(
+	secretStore._credentialApi is None,
+	"The Windows Credential Locker is not available on this system.",
+)
+class CredentialLockerTest(unittest.TestCase):
+	"""Check storing, reading, listing, and removing real credentials."""
+
+	def setUp(self) -> None:
+		self.addCleanup(secretStore.deleteSecret, TEST_ENGINE_ID, "apiKey")
+		_unused = secretStore.deleteSecret(TEST_ENGINE_ID, "apiKey")
+
+	def test_storedValueIsReadBack(self) -> None:
+		"""A stored credential round-trips, including non-ASCII characters."""
+		self.assertTrue(secretStore.setSecret(TEST_ENGINE_ID, "apiKey", "sk-tëst-密钥"))
+		self.assertEqual(secretStore.getSecret(TEST_ENGINE_ID, "apiKey"), "sk-tëst-密钥")
+
+	def test_missingCredentialReadsAsEmpty(self) -> None:
+		"""Reading a credential that was never stored is not an error."""
+		self.assertEqual(secretStore.getSecret(TEST_ENGINE_ID, "apiKey"), "")
+
+	def test_storingAnEmptyValueRemovesTheCredential(self) -> None:
+		"""Clearing a field deletes the stored credential rather than storing a blank one."""
+		self.assertTrue(secretStore.setSecret(TEST_ENGINE_ID, "apiKey", "sk-test"))
+		self.assertTrue(secretStore.setSecret(TEST_ENGINE_ID, "apiKey", "   "))
+		self.assertEqual(secretStore.getSecret(TEST_ENGINE_ID, "apiKey"), "")
+
+	def test_deletingAnAbsentCredentialSucceeds(self) -> None:
+		"""Removal reports success when nothing is stored."""
+		self.assertTrue(secretStore.deleteSecret(TEST_ENGINE_ID, "apiKey"))
+
+	def test_storedCredentialsAreListed(self) -> None:
+		"""Stored credentials can be found again so they can be reported and cleared."""
+		self.assertTrue(secretStore.setSecret(TEST_ENGINE_ID, "apiKey", "sk-test"))
+		self.assertIn(
+			secretStore.getTargetName(TEST_ENGINE_ID, "apiKey"),
+			secretStore.getStoredTargetNames(),
+		)
+
+	def test_oversizedValueIsRejected(self) -> None:
+		"""A value too large for the Credential Locker is refused instead of truncated."""
+		self.assertFalse(secretStore.setSecret(TEST_ENGINE_ID, "apiKey", "x" * 4096))
+		self.assertEqual(secretStore.getSecret(TEST_ENGINE_ID, "apiKey"), "")
+
+
+class UnavailableStoreTest(unittest.TestCase):
+	"""Check that a system without the Credential Locker degrades safely."""
+
+	def test_readingReturnsNothing(self) -> None:
+		"""No credential is invented when there is nowhere to store one."""
+		with patch.object(secretStore, "_credentialApi", None):
+			self.assertEqual(secretStore.getSecret(TEST_ENGINE_ID, "apiKey"), "")
+
+	def test_storingReportsFailure(self) -> None:
+		"""A credential that cannot be stored securely is reported, not silently dropped."""
+		with patch.object(secretStore, "_credentialApi", None):
+			self.assertFalse(secretStore.setSecret(TEST_ENGINE_ID, "apiKey", "sk-test"))
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Fixes #20.

## What changed

API keys, tokens, and passwords are no longer written to `nvda.ini`. They are stored in the **Windows Credential Locker**, where Windows encrypts them for the signed-in account, or can be supplied through **environment variables**.

This addresses every point in the issue:

| Issue | How it is fixed |
| --- | --- |
| Keys survive uninstall | Nothing is left in `nvda.ini`. Credentials in the locker are per-account and encrypted, and can be removed from Windows' own Credential Manager or from the new button in Polyglot's settings. |
| Debug logging publishes every config value | The values are not in the configuration, so they cannot be logged with it. |
| Other add-ons can read the keys through NVDA's config | They are no longer in NVDA's config. |
| No graphical way to clear them | New `Clear Stored API Keys` button in Common Settings, plus Windows' Credential Manager. |
| Portable copies carry the keys | The locker is per-machine, per-Windows-account, and lives outside the NVDA configuration directory. |

## How it works

**`common/secretStore.py`** (new) wraps `CredReadW` / `CredWriteW` / `CredDeleteW` / `CredEnumerateW` through `ctypes`. Credentials are stored as `CRED_TYPE_GENERIC` with `CRED_PERSIST_LOCAL_MACHINE`, under target names of the form `NVDA/Polyglot/<engine>/<setting>` (for example `NVDA/Polyglot/deepl/apiKey`). If the API is unavailable the module degrades safely: reads return an empty string and writes report failure rather than falling back to plain text.

**Environment variables** take precedence over any stored value: `POLYGLOT_` + engine ID + setting name, upper-cased, e.g. `POLYGLOT_DEEPL_APIKEY`, `POLYGLOT_OPENROUTER_APIKEY`, `POLYGLOT_TENCENT_SECRETKEY`. When one is set, the matching settings field is disabled and its label names the variable, so a screen reader user can tell why the field is read-only.

**`views/factory.py`** gains a `PasswordHandler` that backs the existing `password` control type with the secret store instead of the config section, and an `isSecret` flag on the handler contract. `_buildFinalConfigSpec()` skips secret handlers, so password items never enter the add-on's configspec and therefore never reach `nvda.ini`.

**`services/engineManager.py`** gains `getEngineConfigSpec()` (tags each control spec with its owning engine ID, which credential controls need to address the store), `getSecretDefaults()` (cached per engine), and `getResolvedEngineConfig()`, which merges stored credentials into the settings dict handed to an engine at translation time. `manager.py` now uses that instead of `conf["engines"][id].dict()`.

**Migration** runs once at startup: any credential still in `nvda.ini` is moved into the locker and the plain-text copy is removed, then the configuration is saved. Removal happens whether or not the write succeeded — leaving the plain text behind is the bug being fixed — with an error logged telling the user to re-enter the key if secure storage was unavailable. Values equal to a built-in default (Google Translate (Polyglot) ships a shared token) are dropped rather than copied into every user's locker. Migration is skipped in secure mode so a system-account session never copies user credentials into its own locker.

## Notes and deliberate choices

- **No `installTasks.py` / `onUninstall` cleanup.** NVDA runs `onUninstall` for the outgoing version during an *update*, so deleting credentials there would wipe the user's keys on every upgrade. The `Clear Stored API Keys` button and Windows Credential Manager cover deliberate removal instead.
- **Migration covers the base profile and any profile active at startup.** A credential saved under a config profile that is not active at startup is migrated the next time that profile is loaded at startup. NVDA has no public API for marking a named profile dirty, so that path uses a defensive `getattr` and degrades to a no-op if it ever disappears.
- **NVDACN usernames are unchanged.** Only the `password`-typed settings move; usernames stay in the configuration, matching the issue's scope.
- Nothing in `buildVars.py` or `changelog.md` is touched, following the repo's practice of preparing those in a separate release commit.

## Testing

- New `tests/test_secretStore.py`: 13 checks covering target/environment-variable naming, environment override and precedence, real round-trips through the Credential Locker (including non-ASCII), listing, deletion of absent credentials, oversized-value rejection, and safe degradation when the API is unavailable. Locker checks skip themselves where the API is unavailable and clean up after themselves.
- Full suite: 62 tests pass. `ruff check` and `ruff format` are clean.
- Verified against every loaded engine that exactly the 12 `password` settings are recognised as credentials and that each control spec is tagged with its engine ID.

Not yet exercised inside a running NVDA — the settings-panel and migration paths are worth a manual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013613vfcVqUGzT2z4ZR8rXy
